### PR TITLE
Feature/cvsb 19385

### DIFF
--- a/src/models/plates.ts
+++ b/src/models/plates.ts
@@ -30,7 +30,7 @@ export const parsePlates = (platesImage?: DynamoDbImage): Plates => {
 
         plates.push({
             plateSerialNumber: plateImage.getString("plateSerialNumber"),
-            plateIssueDate: plateImage.getString("plateIssueDate"),
+            plateIssueDate: plateImage.getDate("plateIssueDate"),
             plateReasonForIssue: plateImage.getString("plateReasonForIssue") as PlateReasonForIssue,
             plateIssuer: plateImage.getString("plateIssuer"),
             toEmailAddress: plateImage.getString("toEmailAddress")

--- a/src/services/sql-generation.ts
+++ b/src/services/sql-generation.ts
@@ -25,9 +25,9 @@ export const generateFullUpsertSql = (tableDetails: TableDetails): string => {
 };
 
 /**
- * Generate select SQL.
+ * Generate select SQL statement. See sql-execution.ts for a definition of partial upsert if record already exists.
  *
- * @param tableDetails the table to generate select(md5) SQL for
+ * @param tableDetails the table to generate select statement for
  */
 export const generateSelectSql = (tableDetails: TableDetails): string => {
     const query = `SELECT id insertId FROM \`${tableDetails.tableName}\` WHERE fingerprint = MD5(CONCAT_WS('|', ${(nCopies(tableDetails.columnNames.length, "IFNULL(?, '')").join(", "))}))`;

--- a/src/services/sql-generation.ts
+++ b/src/services/sql-generation.ts
@@ -24,6 +24,16 @@ export const generateFullUpsertSql = (tableDetails: TableDetails): string => {
     );
 };
 
+/**
+ * Generate select SQL.
+ *
+ * @param tableDetails the table to generate select(md5) SQL for
+ */
+export const generateSelectSql = (tableDetails: TableDetails): string => {
+    const query = `SELECT id insertId FROM \`${tableDetails.tableName}\` WHERE fingerprint = MD5(CONCAT_WS('|', ${(nCopies(tableDetails.columnNames.length, "IFNULL(?, '')").join(", "))}))`;
+    return query;
+};
+
 const generateUpsertSql = (tableDetails: TableDetails, updatePlaceholders: string[]): string => {
     return `INSERT INTO \`${tableDetails.tableName}\` (${tableDetails.columnNames.map((c) => `\`${c}\``).join(", ")})`
         + ` VALUES (${(nCopies(tableDetails.columnNames.length, "?").join(", "))})`

--- a/src/services/tech-record-document-conversion.ts
+++ b/src/services/tech-record-document-conversion.ts
@@ -39,7 +39,7 @@ const upsertTechRecords = async (techRecordDocument: TechRecordDocument): Promis
     const vehicleConnection = await pool.getConnection();
 
     try {
-        await vehicleConnection.execute('SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED');
+        await vehicleConnection.execute("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED");
         await vehicleConnection.beginTransaction();
 
         vehicleId = await upsertVehicle(vehicleConnection, techRecordDocument);
@@ -67,17 +67,17 @@ const upsertTechRecords = async (techRecordDocument: TechRecordDocument): Promis
         const techRecordConnection = await pool.getConnection();
 
         try {
-            await vehicleConnection.execute('SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED');
-            
+            await vehicleConnection.execute("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED");
+
             debugLog(`upsertTechRecords: Upserting tech record...`);
-            
+
             const makeModelId = await upsertMakeModel(techRecordConnection, techRecord);
             const vehicleClassId = await upsertVehicleClass(techRecordConnection, techRecord);
             const vehicleSubclassIds = await upsertVehicleSubclasses(techRecordConnection, vehicleClassId, techRecord);
             const createdById = await upsertIdentity(techRecordConnection, techRecord.createdById!, techRecord.createdByName!);
             const lastUpdatedById = await upsertIdentity(techRecordConnection, techRecord.lastUpdatedById!, techRecord.lastUpdatedByName!);
             const contactDetailsId = await upsertContactDetails(techRecordConnection, techRecord);
-            
+
             await techRecordConnection.beginTransaction();
 
             const response = await executeFullUpsert(

--- a/src/services/tech-record-document-conversion.ts
+++ b/src/services/tech-record-document-conversion.ts
@@ -15,7 +15,7 @@ import {
     VEHICLE_SUBCLASS_TABLE,
     VEHICLE_TABLE
 } from "./table-details";
-import {executeFullUpsert, executePartialUpsert} from "./sql-execution";
+import {executeFullUpsert, executePartialUpsert, executePartialUpsertIfNotExists} from "./sql-execution";
 import {TechRecordUpsertResult} from "../models/upsert-results";
 import {getConnectionPool} from "./connection-pool";
 import {Connection} from "mysql2/promise";
@@ -236,7 +236,7 @@ const upsertVehicle = async (connection: Connection, techRecordDocument: TechRec
 const upsertMakeModel = async (connection: Connection, techRecord: TechRecord): Promise<number> => {
     debugLog(`upsertTechRecords: Upserting make-model...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         MAKE_MODEL_TABLE,
         [
             techRecord.make,
@@ -262,7 +262,7 @@ const upsertMakeModel = async (connection: Connection, techRecord: TechRecord): 
 const upsertVehicleClass = async (connection: Connection, techRecord: TechRecord): Promise<number> => {
     debugLog(`upsertTechRecords: Upserting vehicle class...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         VEHICLE_CLASS_TABLE,
         [
             techRecord.vehicleClass?.code,
@@ -313,7 +313,7 @@ const upsertVehicleSubclasses = async (connection: Connection, vehicleClassId: n
 const upsertIdentity = async (connection: Connection, id: string, name: string): Promise<number> => {
     debugLog(`upsertTechRecords: Upserting identity (${id} ---> ${name})...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         IDENTITY_TABLE,
         [
             id,
@@ -330,7 +330,7 @@ const upsertIdentity = async (connection: Connection, id: string, name: string):
 const upsertContactDetails = async (connection: Connection, techRecord: TechRecord): Promise<number> => {
     debugLog(`upsertTechRecords: Upserting contact details...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         CONTACT_DETAILS_TABLE,
         [
             techRecord.applicantDetails?.name,

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -16,7 +16,7 @@ import {
     VEHICLE_SUBCLASS_TABLE,
     VEHICLE_TABLE
 } from "./table-details";
-import {executePartialUpsert} from "./sql-execution";
+import {executePartialUpsert, executePartialUpsertIfNotExists} from "./sql-execution";
 import {TestResultUpsertResult} from "../models/upsert-results";
 import {getConnectionPool} from "./connection-pool";
 import {Connection} from "mysql2/promise";
@@ -194,7 +194,7 @@ const upsertVehicle = async (connection: Connection, testResult: TestResult): Pr
 const upsertTestStation = async (connection: Connection, testResult: TestResult): Promise<number> => {
     debugLog(`upsertTestResults: Upserting test station...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         TEST_STATION_TABLE,
         [
             testResult.testStationPNumber,
@@ -212,7 +212,7 @@ const upsertTestStation = async (connection: Connection, testResult: TestResult)
 const upsertTester = async (connection: Connection, testResult: TestResult): Promise<number> => {
     debugLog(`upsertTestResults: Upserting tester...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         TESTER_TABLE,
         [
             testResult.testerStaffId,
@@ -230,7 +230,7 @@ const upsertTester = async (connection: Connection, testResult: TestResult): Pro
 const upsertVehicleClass = async (connection: Connection, testResult: TestResult): Promise<number> => {
     debugLog(`upsertTestResults: Upserting vehicle class...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         VEHICLE_CLASS_TABLE,
         [
             testResult.vehicleClass?.code,
@@ -315,7 +315,7 @@ const upsertTestType = async (connection: Connection, testType: TestType): Promi
 const upsertPreparer = async (connection: Connection, testResult: TestResult): Promise<number> => {
     debugLog(`upsertTestResults: Upserting preparer...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         PREPARER_TABLE,
         [
             testResult.preparerId,
@@ -332,7 +332,7 @@ const upsertPreparer = async (connection: Connection, testResult: TestResult): P
 const upsertIdentity = async (connection: Connection, id: string, name: string): Promise<number> => {
     debugLog(`upsertTestResults: Upserting identity (${id} ---> ${name})...`);
 
-    const response = await executePartialUpsert(
+    const response = await executePartialUpsertIfNotExists(
         IDENTITY_TABLE,
         [
             id,
@@ -356,7 +356,7 @@ const upsertDefects = async (connection: Connection, testResultId: number, testT
     for (const defect of testType.defects) {
         debugLog(`upsertTestResults: Upserting defect...`);
 
-        const insertDefectResponse = await executePartialUpsert(
+        const insertDefectResponse = await executePartialUpsertIfNotExists(
             DEFECTS_TABLE,
             [
                 defect.imNumber,
@@ -379,7 +379,7 @@ const upsertDefects = async (connection: Connection, testResultId: number, testT
 
         insertedIds.push(defectId);
 
-        const insertLocationResponse = await executePartialUpsert(
+        const insertLocationResponse = await executePartialUpsertIfNotExists(
             LOCATION_TABLE,
             [
                 defect.additionalInformation?.location?.vertical,

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -51,7 +51,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<TestResultUp
 
         let vehicleId;
         try {
-            await vehicleConnection.execute('SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED');
+            await vehicleConnection.execute("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED");
             await vehicleConnection.beginTransaction();
 
             vehicleId = await upsertVehicle(vehicleConnection, testResult);
@@ -68,8 +68,8 @@ const upsertTestResults = async (testResults: TestResults): Promise<TestResultUp
         const testResultConnection = await pool.getConnection();
 
         try {
-            await testResultConnection.execute('SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED');
-            
+            await testResultConnection.execute("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED");
+
             const testStationId = await upsertTestStation(testResultConnection, testResult);
             const testerId = await upsertTester(testResultConnection, testResult);
             const vehicleClassId = await upsertVehicleClass(testResultConnection, testResult);
@@ -77,9 +77,9 @@ const upsertTestResults = async (testResults: TestResults): Promise<TestResultUp
             const preparerId = await upsertPreparer(testResultConnection, testResult);
             const createdById = await upsertIdentity(testResultConnection, testResult.createdById!, testResult.createdByName!);
             const lastUpdatedById = await upsertIdentity(testResultConnection, testResult.lastUpdatedById!, testResult.lastUpdatedByName!);
-            
+
             await testResultConnection.beginTransaction();
-            
+
             for (const testType of testResult.testTypes!) {
                 const fuelEmissionId = await upsertFuelEmission(testResultConnection, testType);
                 const testTypeId = await upsertTestType(testResultConnection, testType);

--- a/tests/unit/services/sql-execution.unitTest.ts
+++ b/tests/unit/services/sql-execution.unitTest.ts
@@ -1,7 +1,7 @@
-import {executeFullUpsert, executePartialUpsert} from "../../../src/services/sql-execution";
+import {executeFullUpsert, executePartialUpsert, executePartialUpsertIfNotExists} from "../../../src/services/sql-execution";
 import {executeSql} from "../../../src/services/connection-pool";
 import {TECHNICAL_RECORD_TABLE} from "../../../src/services/table-details";
-import {generateFullUpsertSql, generatePartialUpsertSql} from "../../../src/services/sql-generation";
+import {generateFullUpsertSql, generatePartialUpsertSql, generateSelectSql} from "../../../src/services/sql-generation";
 
 describe("executePartialUpsert()", () => {
     it("should call partial upsert SQL generation", () => {
@@ -36,5 +36,42 @@ describe("executeFullUpsert()", () => {
         expect(executeSql).toHaveBeenCalledTimes(1);
         expect(generateFullUpsertSql).toHaveBeenCalledTimes(1);
         expect(executeSql).toHaveBeenCalledWith("SELECT 1", [], undefined);
+    });
+});
+
+describe("executePartialUpsertIfNotExists()", () => {
+    it("should call partial upsert SQL generation if no row exists", () => {
+        (generateSelectSql as jest.Mock) = jest.fn().mockReturnValue("SELECT 1");
+        (generatePartialUpsertSql as jest.Mock) = jest.fn().mockReturnValue("INSERT INTO table_name () VALUES () ON DUPLICATE KEY");
+       
+        (executeSql as jest.Mock) = jest.fn()
+        .mockResolvedValue({    
+                rows: [{'column': 1}],
+                fields: []});
+        // @ts-ignore
+        executePartialUpsertIfNotExists(TECHNICAL_RECORD_TABLE, [], undefined);
+
+        expect(executeSql).toHaveBeenCalledTimes(1);
+        expect(executeSql).toHaveBeenCalledWith("SELECT 1", [], undefined);
+        expect(generateSelectSql).toHaveBeenCalledTimes(1);
+    });
+    it("should call partial upsert SQL generation if row exists", () => {
+        (generateSelectSql as jest.Mock) = jest.fn().mockReturnValue("SELECT 1");
+        (generatePartialUpsertSql as jest.Mock) = jest.fn().mockReturnValue("INSERT INTO table_name () VALUES () ON DUPLICATE KEY");
+       
+        (executeSql as jest.Mock) = jest.fn()
+        .mockResolvedValueOnce({    
+                rows: [],
+                fields: []})
+        .mockResolvedValue({
+                rows: [{'column': 1}],
+                fields: []
+        });
+        // @ts-ignore
+        executePartialUpsertIfNotExists(TECHNICAL_RECORD_TABLE, [], undefined);
+
+        expect(executeSql).toHaveBeenCalledTimes(1);
+        expect(executeSql).toHaveBeenCalledWith("SELECT 1", [], undefined);
+        expect(generateSelectSql).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/unit/services/sql-generation.unitTest.ts
+++ b/tests/unit/services/sql-generation.unitTest.ts
@@ -1,4 +1,4 @@
-import {generateFullUpsertSql, generatePartialUpsertSql} from "../../../src/services/sql-generation";
+import {generateFullUpsertSql, generatePartialUpsertSql, generateSelectSql} from "../../../src/services/sql-generation";
 
 const tableName = "myTable";
 const columnNames = ["columnA", "columnZ"];
@@ -27,6 +27,14 @@ describe("generateFullUpsertSql", () => {
     it("should generate correct SQL when PK is provided", async () => {
         expect(generateFullUpsertSql({ tableName, columnNames, primaryKeyColumnName: "myId"})).toEqual(
             "INSERT INTO `myTable` (`columnA`, `columnZ`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `myId` = LAST_INSERT_ID(`myId`), `columnA` = ?, `columnZ` = ?"
+        );
+    });
+});
+
+describe("generateSelectSql", () => {
+    it("should generate correct SELECT SQL with MD5 function clause, and columns placeholder", async () => {
+        expect(generateSelectSql({ tableName, columnNames })).toEqual(
+            "SELECT id insertId FROM `myTable` WHERE fingerprint = MD5(CONCAT_WS('|', IFNULL(?, ''), IFNULL(?, '')))"
         );
     });
 });


### PR DESCRIPTION
Changes :
- added new function executePartialUpsertIfNotExists() - check if the record exists before running Insert (reference tables only)
- explicit change of session transaction isolation REPEATABLE-READ(default) -> READ-COMMITTED
- excluding (where possible) reference data inserts from transaction blocks (shorter-quicker transaction)