### PR TITLE
feat(cb2-3183): allow events from flat-tech-records dynamo to be processed by update-store

### DIFF
--- a/src/services/entity-conversion.ts
+++ b/src/services/entity-conversion.ts
@@ -44,7 +44,7 @@ export const convert = async <T> (tableName: string, sqlOperation: SqlOperation,
 };
 
 const getEntityConverter = <T> (tableName: string): EntityConverter<T> => {
-    if (tableName.includes("technical-records")) {
+    if (tableName.includes("technical-records") || tableName.includes('flat-tech-records')) {
         tableName = "technical-records";
     } else if (tableName.includes("test-results")) {
         tableName = "test-results";

--- a/src/services/entity-conversion.ts
+++ b/src/services/entity-conversion.ts
@@ -44,7 +44,7 @@ export const convert = async <T> (tableName: string, sqlOperation: SqlOperation,
 };
 
 const getEntityConverter = <T> (tableName: string): EntityConverter<T> => {
-    if (tableName.includes("technical-records") || tableName.includes('flat-tech-records')) {
+    if (tableName.includes("technical-records") || tableName.includes("flat-tech-records")) {
         tableName = "technical-records";
     } else if (tableName.includes("test-results")) {
         tableName = "test-results";


### PR DESCRIPTION
### NOP receives vehicle technical record data from new flat-technical-records DynamoDB

The `cvs-edh-dispatcher-technical_records-queue` SQS queue that feeds into the `update-store` lambda now handles stream events from the `flat-tech-records` DynamoDB that has been created as part of [this work](https://dvsa.atlassian.net/browse/CB2-3462). 

The `update-store` lambda decides how it handles inbound stream events based on the ARN of the inbound event. In this case `flat-tech-records` has had to be added to the filtering that the `update-store` lambda does in order to handle these stream events in the same way as stream events from `technical-records` DynamoDB (they share the same data structure at the point that the `update-store` lambda receives the events)

[Link to JIRA ticket](https://dvsa.atlassian.net/browse/CB2-3183)