### PR TITLE
(Fix: CB2-4183) Fix for EVL feed - to support cherished transfers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sonar-scanner": "sonar-scanner",
     "audit": "npm audit",
     "package": "mkdir -p ${ZIP_NAME} && cp package.json package-lock.json ${ZIP_NAME}/ && cp -r .build/src/* ${ZIP_NAME}/ && cd ${ZIP_NAME} && npm ci --production && rm package.json package-lock.json && zip -qr ../${ZIP_NAME}.zip .",
-    "security-checks": "git secrets --register-aws && git secrets --scan && git log -p | scanrepo",
+    "security-checks": "git secrets --register-aws && git secrets --scan",
     "tools-setup": "liquibase --changeLogFile ../cvs-nop/changelog-master.xml --username root --password 12345 --url jdbc:mysql://127.0.0.1:3306/CVSBNOP?createDatabaseIfNotExist=true --classpath /liquibase/lib/mysql.jar update"
   },
   "nyc": {

--- a/src/services/tech-record-document-conversion.ts
+++ b/src/services/tech-record-document-conversion.ts
@@ -219,7 +219,7 @@ const deleteTechRecords = async (techRecordDocument: TechRecordDocument): Promis
 const upsertVehicle = async (connection: Connection, techRecordDocument: TechRecordDocument): Promise<number> => {
     debugLog(`upsertTechRecords: Upserting vehicle...`);
 
-    const response = await executePartialUpsert(
+    const response = await executeFullUpsert(
         VEHICLE_TABLE,
         [
             techRecordDocument.systemNumber,


### PR DESCRIPTION
## Fix lambda to allow existing Vehicle records updates

Fix changes the way data in Vehicle table is populated when passing record matches unique key (SystemNumber, VIN) - to support cherished transfer (where new VRM is assigned to existing vehicle).

[Jira - CB2-4183](https://dvsa.atlassian.net/browse/CB2-4183)

SCANREPO has been removed from `security-checks` as it is deemed to be decommissioned. 

## Checklist
- [x] Regression pack run on a branch (FEATURE_TEST_BACKEND_VOTT), tested locally unit/integration tests
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number