### PR TITLE
CB2-7559 Allow string to be used when expecting number attribute

### DIFF
--- a/src/services/dynamodb-images.ts
+++ b/src/services/dynamodb-images.ts
@@ -215,7 +215,7 @@ export class DynamoDbImage {
                 return defaultValue;
             }
             default: {
-                verifyType(expectedType, field);
+                verifyType(expectedType, field, field.value);
                 return parser(field.value);
             }
         }
@@ -224,10 +224,13 @@ export class DynamoDbImage {
 
 const padToTwo = (digit: number): string => {
     return digit > 9 ? digit.toString() : "0" + digit;
-  };
+};
 
-const verifyType = (expectedType: DynamoDbType, field: DynamoDbField) => {
+const verifyType = (expectedType: DynamoDbType, field: DynamoDbField, value: any) => {
     if (expectedType !== field.type) {
+        if (expectedType === "N" && field.type === "S" && !isNaN(value) && !isNaN(parseFloat(value))) {
+            return;
+        }
         throw new Error(`field ${field.key} is not of type "${expectedType}" (actual: "${field.type}")`);
     }
 };

--- a/tests/unit/services/dynamodb-images.unitTest.ts
+++ b/tests/unit/services/dynamodb-images.unitTest.ts
@@ -57,4 +57,49 @@ describe("parse()", () => {
         const image = DynamoDbImage.parse(castToImageShape(primitivesJson));
         expect(() => image.getString("NumberField")).toThrowError("not of type");
     });
+    
+    it("should handle a number when presented as a null", () => {
+        let image = DynamoDbImage.parse(castToImageShape({ NumberField: {NULL: true} }));
+        expect(image.getNumber("NumberField")).toEqual(undefined);
+    });
+    
+    it("should handle a number when presented as a string", () => {
+        let image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "2.2"} }));
+        expect(image.getNumber("NumberField")).toEqual(2.2);
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "22"} }));
+        expect(image.getNumber("NumberField")).toEqual(22);
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "-2.2"} }));
+        expect(image.getNumber("NumberField")).toEqual(-2.2);
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: ".2"} }));
+        expect(image.getNumber("NumberField")).toEqual(0.2);
+    });
+    
+    it("should reject a number when presented as non numerical strings", () => {
+        let image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: " "} }));
+        expect(() => image.getNumber("NumberField")).toThrowError("not of type");
+
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: ""} }));
+        expect(() => image.getNumber("NumberField")).toThrowError("not of type");
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "."} }));
+        expect(() => image.getNumber("NumberField")).toThrowError("not of type");
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "1.."} }));
+        expect(() => image.getNumber("NumberField")).toThrowError("not of type");
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "..1"} }));
+        expect(() => image.getNumber("NumberField")).toThrowError("not of type");
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "1aa"} }));
+        expect(() => image.getNumber("NumberField")).toThrowError("not of type");
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "aa1"} }));
+        expect(() => image.getNumber("NumberField")).toThrowError("not of type");
+        
+        image = DynamoDbImage.parse(castToImageShape({ NumberField: {S: "string"} }));
+        expect(() => image.getNumber("NumberField")).toThrowError("not of type");
+    });
 });


### PR DESCRIPTION
## Issue
After the initial preprod nop rebuild it was discovered that 89,423 technical records had numberOfWheelsDriven as a string rather than a number. The update-store validates the expected type against the attribute's type and throws an error if they don't match.
## Fix
If the types don't match, perform a second check. If the expected type is a number and the actual type a string which is a number, then allow the value to be used.

Related issue: [CB2-7559](https://dvsa.atlassian.net/browse/CB2-7559)