### PR TITLE
CB2-7593: Clean vins before inserting into NOP

### DIFF
--- a/src/services/tech-record-document-conversion.ts
+++ b/src/services/tech-record-document-conversion.ts
@@ -21,7 +21,7 @@ import {getConnectionPool} from "./connection-pool";
 import {Connection} from "mysql2/promise";
 import {EntityConverter} from "./entity-conversion";
 import {debugLog} from "./logger";
-import "../utils/cleanser";
+import { vinCleanser } from "../utils/cleanser";
 
 export const techRecordDocumentConverter = (): EntityConverter<TechRecordDocument> => {
     return {
@@ -224,7 +224,7 @@ const upsertVehicle = async (connection: Connection, techRecordDocument: TechRec
         VEHICLE_TABLE,
         [
             techRecordDocument.systemNumber,
-            techRecordDocument.vin,
+            vinCleanser(techRecordDocument.vin),
             techRecordDocument.primaryVrm,
             techRecordDocument.trailerId,
             new Date().toISOString().substring(0, 23)

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -22,7 +22,7 @@ import {getConnectionPool} from "./connection-pool";
 import {Connection} from "mysql2/promise";
 import {EntityConverter} from "./entity-conversion";
 import {debugLog} from "./logger";
-import "../utils/cleanser";
+import { vinCleanser } from "../utils/cleanser";
 
 export const testResultsConverter = (): EntityConverter<TestResults> => {
     return {
@@ -183,10 +183,10 @@ const upsertVehicle = async (connection: Connection, testResult: TestResult): Pr
         VEHICLE_TABLE,
         [
             testResult.systemNumber,
-            testResult.vin,
+            vinCleanser(testResult.vin),
             testResult.vrm,
             testResult.trailerId,
-            new Date().toISOString().substr(0, 23)
+            new Date().toISOString().substring(0, 23)
         ],
         connection
     );

--- a/src/utils/cleanser.ts
+++ b/src/utils/cleanser.ts
@@ -1,5 +1,3 @@
-export {};
-
 declare global {
   interface Array<T> {
     /**
@@ -23,4 +21,8 @@ if (!Array.prototype.fingerprintCleanser) {
         .map((i) => i === "" ? null : i);
     }
   });
+}
+
+export function vinCleanser(vin: string | undefined): string {
+  return vin ? vin.replace(/[^a-zA-Z0-9]/g, "") : "";
 }

--- a/tests/integration/tech-record-document-conversion.intTest.ts
+++ b/tests/integration/tech-record-document-conversion.intTest.ts
@@ -474,7 +474,7 @@ describe("convertTechRecordDocument() integration tests", () => {
             // arrange - create a record so we can later query for it and assert for is existence
             const techRecordDocumentJsonNew = techRecordDocumentJson;
             techRecordDocumentJsonNew.systemNumber = {S : "SYSTEM-NUMBER-2"};
-            techRecordDocumentJsonNew.vin =  {S : "VIN-2"};
+            techRecordDocumentJsonNew.vin =  {S : "VIN2"};
             techRecordDocumentJsonNew.primaryVrm =  {S : "VRM7777"};
 
             const event = {
@@ -511,7 +511,7 @@ describe("convertTechRecordDocument() integration tests", () => {
 
             expect(vehicleResultSet.rows.length).toEqual(1);
             expect(vehicleResultSet.rows[0].system_number).toEqual("SYSTEM-NUMBER-2");
-            expect(vehicleResultSet.rows[0].vin).toEqual("VIN-2");
+            expect(vehicleResultSet.rows[0].vin).toEqual("VIN2");
             expect(vehicleResultSet.rows[0].vrm_trm).toEqual("VRM7777");
             expect(vehicleResultSet.rows[0].trailer_id).toEqual("88888888");
             expect((vehicleResultSet.rows[0].createdAt as Date).toUTCString()).not.toBeNull(); // todo This returns null
@@ -522,7 +522,7 @@ describe("convertTechRecordDocument() integration tests", () => {
             // arrange - create a record with existing pair of (SystemNumber, VIN) and new VRM so we can later query for it and assert its value
             const techRecordDocumentJsonNew = techRecordDocumentJson;
             techRecordDocumentJsonNew.systemNumber = {S : "SYSTEM-NUMBER-2"};
-            techRecordDocumentJsonNew.vin =  {S : "VIN-2"};
+            techRecordDocumentJsonNew.vin =  {S : "VIN2"};
             techRecordDocumentJsonNew.primaryVrm =  {S : "VRM888NEW"};
 
             const event = {
@@ -559,7 +559,7 @@ describe("convertTechRecordDocument() integration tests", () => {
 
             expect(vehicleResultSet.rows.length).toEqual(1);
             expect(vehicleResultSet.rows[0].system_number).toEqual("SYSTEM-NUMBER-2");
-            expect(vehicleResultSet.rows[0].vin).toEqual("VIN-2");
+            expect(vehicleResultSet.rows[0].vin).toEqual("VIN2");
             expect(vehicleResultSet.rows[0].vrm_trm).toEqual("VRM888NEW");
             expect(vehicleResultSet.rows[0].trailer_id).toEqual("88888888");
             expect((vehicleResultSet.rows[0].createdAt as Date).toUTCString()).not.toBeNull(); // todo This returns null

--- a/tests/utils/cleanser.unitTest.ts
+++ b/tests/utils/cleanser.unitTest.ts
@@ -1,5 +1,6 @@
 import { BodyType } from "../../src/models/body-type";
-import "../../src/utils/cleanser";
+import { TechRecordDocument } from "../../src/models/tech-record-document";
+import { vinCleanser } from "../../src/utils/cleanser";
 
 describe("fingerprintCleanser function", () => {
     it("should trim and null empty strings from data", () => {
@@ -37,5 +38,23 @@ describe("fingerprintCleanser function", () => {
         expect(cleansedData[4]).toBe(expectedCleansedData[4]);
         expect(cleansedData[5]).toBe(expectedCleansedData[5]);
         expect(cleansedData[6]).toBe(expectedCleansedData[6]);
+    });
+});
+
+describe("vinCleanser function", () => {
+    it("should remove all non alphanumeric characters", () => {
+        const techRecord: TechRecordDocument = {
+            vin: " V!I-N&1[2    ]3`45      "
+        };
+        const cleansedVin = vinCleanser(techRecord.vin);
+
+        expect(cleansedVin).toBe("VIN12345");
+    });
+
+    it("should convert a null vin to an empty string", () => {
+        const techRecord: TechRecordDocument = {};
+        const cleansedVin = vinCleanser(techRecord.vin);
+
+        expect(cleansedVin).toBe("");
     });
 });


### PR DESCRIPTION
## Description
A lot of vehicles have empty (whitespaces) VINs. These need to be converted to an empty string before inserting into NOP. Also, during the preprod NOP rebuild, it was noticed that some VINs have special characters. For example whitespace and slashes, and sometimes in the middle of a VIN. These need to be removed.

Related issue: [CB2-7593](https://dvsa.atlassian.net/browse/CB2-7593)
Related issue: [CB2-7557](https://dvsa.atlassian.net/browse/CB2-7557)