### PR TITLE
CB2-7564: Throw error on missing systemNumber

### DIFF
--- a/tests/resources/dynamodb-image-test-results-with-no-systemNumber.json
+++ b/tests/resources/dynamodb-image-test-results-with-no-systemNumber.json
@@ -1,7 +1,4 @@
 {
-  "systemNumber": {
-    "S": "SYSTEM-NUMBER-1"
-  },
   "vrm": {
     "S": "VRM"
   },

--- a/tests/resources/dynamodb-image-test-results.json
+++ b/tests/resources/dynamodb-image-test-results.json
@@ -1,344 +1,336 @@
 {
-  "testResults": {
+  "systemNumber": {
+    "S": "SYSTEM-NUMBER"
+  },
+  "vrm": {
+    "S": "VRM"
+  },
+  "trailerId": {
+    "S": "88888888"
+  },
+  "vin": {
+    "S": "VIN"
+  },
+  "vehicleId": {
+    "S": "VEHICLE-ID"
+  },
+  "testHistory": {
+    "L": []
+  },
+  "testVersion": {
+    "S": "TEST-VERSION"
+  },
+  "reasonForCreation": {
+    "S": "REASON-FOR-CREATION"
+  },
+  "createdAt": {
+    "S": "2020-01-01T00:00:00.000Z"
+  },
+  "createdByName": {
+    "S": "CREATED-BY-NAME"
+  },
+  "createdById": {
+    "S": "CREATED-BY-ID"
+  },
+  "lastUpdatedAt": {
+    "S": "2020-01-01T00:00:00.000Z"
+  },
+  "lastUpdatedByName": {
+    "S": "LAST-UPDATED-BY-NAME"
+  },
+  "lastUpdatedById": {
+    "S": "LAST-UPDATED-BY-ID"
+  },
+  "shouldEmailCertificate": {
+    "S": "SHOULD-EMAIL-CERTIFICATE"
+  },
+  "testStationName": {
+    "S": "TEST-STATION-NAME"
+  },
+  "testStationPNumber": {
+    "S": "P-NUMBER"
+  },
+  "testStationType": {
+    "S": "atf"
+  },
+  "testerName": {
+    "S": "TESTER-NAME"
+  },
+  "testerStaffId": {
+    "S": "999999999"
+  },
+  "testResultId": {
+    "S": "TEST-RESULT-ID"
+  },
+  "testerEmailAddress": {
+    "S": "TESTER-EMAIL-ADDRESS"
+  },
+  "testStartTimestamp": {
+    "S": "2020-01-01T00:00:00.000Z"
+  },
+  "testEndTimestamp": {
+    "S": "2020-01-01T00:00:00.000Z"
+  },
+  "testStatus": {
+    "S": "submitted"
+  },
+  "reasonForCancellation": {
+    "S": "REASON-FOR-CANCELLATION"
+  },
+  "vehicleClass": {
+    "M": {
+      "code": {
+        "S": "2"
+      },
+      "description": {
+        "S": "motorbikes over 200cc or with a sidecar"
+      }
+    }
+  },
+  "vehicleSubclass": {
+    "L": [
+      {
+        "S": "1"
+      }
+    ]
+  },
+  "vehicleType": {
+    "S": "psv"
+  },
+  "numberOfSeats": {
+    "N": "1"
+  },
+  "vehicleConfiguration": {
+    "S": "rigid"
+  },
+  "odometerReading": {
+    "N": "1"
+  },
+  "odometerReadingUnits": {
+    "S": "KILOMETRES"
+  },
+  "preparerId": {
+    "S": "999999999"
+  },
+  "preparerName": {
+    "S": "PREPARER-NAME"
+  },
+  "numberOfWheelsDriven": {
+    "N": "1"
+  },
+  "euVehicleCategory": {
+    "S": "m1"
+  },
+  "countryOfRegistration": {
+    "S": "COUNTRY-OF-REGISTRATION"
+  },
+  "vehicleSize": {
+    "S": "large"
+  },
+  "noOfAxles": {
+    "N": "1"
+  },
+  "regnDate": {
+    "S": "2020-01-01"
+  },
+  "firstUseDate": {
+    "S": "2020-01-01"
+  },
+  "testTypes": {
     "L": [
       {
         "M": {
-          "systemNumber": {
-            "S": "SYSTEM-NUMBER"
-          },
-          "vrm": {
-            "S": "VRM"
-          },
-          "trailerId": {
-            "S": "88888888"
-          },
-          "vin": {
-            "S": "VIN"
-          },
-          "vehicleId": {
-            "S": "VEHICLE-ID"
-          },
-          "testHistory": {
-            "L": []
-          },
-          "testVersion": {
-            "S": "TEST-VERSION"
-          },
-          "reasonForCreation": {
-            "S": "REASON-FOR-CREATION"
-          },
           "createdAt": {
-            "S": "2020-01-01T00:00:00.000Z"
-          },
-          "createdByName": {
-            "S": "CREATED-BY-NAME"
-          },
-          "createdById": {
-            "S": "CREATED-BY-ID"
+            "S": "2020-01-01T00:00:00.123Z"
           },
           "lastUpdatedAt": {
             "S": "2020-01-01T00:00:00.000Z"
           },
-          "lastUpdatedByName": {
-            "S": "LAST-UPDATED-BY-NAME"
+          "deletionFlag": {
+            "BOOL": true
           },
-          "lastUpdatedById": {
-            "S": "LAST-UPDATED-BY-ID"
+          "testCode": {
+            "S": "333"
           },
-          "shouldEmailCertificate": {
-            "S": "SHOULD-EMAIL-CERTIFICATE"
+          "testTypeClassification": {
+            "S": "2323232323232323232323"
           },
-          "testStationName": {
-            "S": "TEST-STATION-NAME"
+          "testTypeName": {
+            "S": "TEST-TYPE-NAME"
           },
-          "testStationPNumber": {
-            "S": "P-NUMBER"
+          "name": {
+            "S": "NAME"
           },
-          "testStationType": {
-            "S": "atf"
+          "testTypeId": {
+            "S": "TEST-TYPE-ID"
           },
-          "testerName": {
-            "S": "TESTER-NAME"
+          "testNumber": {
+            "S": "TEST-NUMBER"
           },
-          "testerStaffId": {
+          "certificateNumber": {
             "S": "999999999"
           },
-          "testResultId": {
-            "S": "TEST-RESULT-ID"
+          "secondaryCertificateNumber": {
+            "S": "999999999"
           },
-          "testerEmailAddress": {
-            "S": "TESTER-EMAIL-ADDRESS"
+          "certificateLink": {
+            "S": "CERTIFICATE-LINK"
           },
-          "testStartTimestamp": {
+          "testExpiryDate": {
             "S": "2020-01-01T00:00:00.000Z"
           },
-          "testEndTimestamp": {
+          "testAnniversaryDate": {
             "S": "2020-01-01T00:00:00.000Z"
           },
-          "testStatus": {
-            "S": "submitted"
+          "testTypeStartTimestamp": {
+            "S": "2020-01-01T00:00:00.023Z"
           },
-          "reasonForCancellation": {
-            "S": "REASON-FOR-CANCELLATION"
+          "testTypeEndTimestamp": {
+            "S": "2020-01-01T00:00:00.000Z"
           },
-          "vehicleClass": {
+          "statusUpdatedFlag": {
+            "BOOL": true
+          },
+          "numberOfSeatbeltsFitted": {
+            "N": "1"
+          },
+          "lastSeatbeltInstallationCheckDate": {
+            "S": "2020-01-01"
+          },
+          "seatbeltInstallationCheckDate": {
+            "BOOL": true
+          },
+          "testResult": {
+            "S": "fail"
+          },
+          "prohibitionIssued": {
+            "BOOL": true
+          },
+          "reasonForAbandoning": {
+            "S": "REASON-FOR-ABANDONING"
+          },
+          "additionalNotesRecorded": {
+            "S": "ADDITIONAL-NOTES-RECORDED"
+          },
+          "additionalCommentsForAbandon": {
+            "S": "ADDITIONAL-COMMENTS-FOR-ABANDON"
+          },
+          "modType": {
             "M": {
               "code": {
-                "S": "2"
+                "S": "p"
               },
               "description": {
-                "S": "motorbikes over 200cc or with a sidecar"
+                "S": "particulate trap"
               }
             }
           },
-          "vehicleSubclass": {
-            "L": [
-              {
-                "S": "1"
-              }
-            ]
+          "emissionStandard": {
+            "S": "0.10 g/kWh Euro 3 PM"
           },
-          "vehicleType": {
-            "S": "psv"
+          "fuelType": {
+            "S": "diesel"
           },
-          "numberOfSeats": {
-            "N": "1"
+          "particulateTrapFitted": {
+            "S": "PARTICULATE-TRAP-FITTED"
           },
-          "vehicleConfiguration": {
-            "S": "rigid"
+          "particulateTrapSerialNumber": {
+            "S": "PARTICULATE-TRAP-SERIAL-NUMBER"
           },
-          "odometerReading": {
-            "N": "1"
+          "modificationTypeUsed": {
+            "S": "MODIFICATION-TYPE-USED"
           },
-          "odometerReadingUnits": {
-            "S": "KILOMETRES"
+          "smokeTestKLimitApplied": {
+            "S": "SMOKE-TEST-K-LIMIT-APPLIED"
           },
-          "preparerId": {
-            "S": "999999999"
-          },
-          "preparerName": {
-            "S": "PREPARER-NAME"
-          },
-          "numberOfWheelsDriven": {
-            "N": "1"
-          },
-          "euVehicleCategory": {
-            "S": "m1"
-          },
-          "countryOfRegistration": {
-            "S": "COUNTRY-OF-REGISTRATION"
-          },
-          "vehicleSize": {
-            "S": "large"
-          },
-          "noOfAxles": {
-            "N": "1"
-          },
-          "regnDate": {
-            "S": "2020-01-01"
-          },
-          "firstUseDate": {
-            "S": "2020-01-01"
-          },
-          "testTypes": {
+          "defects": {
             "L": [
               {
                 "M": {
-                  "createdAt": {
-                    "S": "2020-01-01T00:00:00.123Z"
-                  },
-                  "lastUpdatedAt": {
-                    "S": "2020-01-01T00:00:00.000Z"
-                  },
-                  "deletionFlag": {
-                    "BOOL": true
-                  },
-                  "testCode": {
-                    "S": "333"
-                  },
-                  "testTypeClassification": {
-                    "S": "2323232323232323232323"
-                  },
-                  "testTypeName": {
-                    "S": "TEST-TYPE-NAME"
-                  },
-                  "name": {
-                    "S": "NAME"
-                  },
-                  "testTypeId": {
-                    "S": "TEST-TYPE-ID"
-                  },
-                  "testNumber": {
-                    "S": "TEST-NUMBER"
-                  },
-                  "certificateNumber": {
-                    "S": "999999999"
-                  },
-                  "secondaryCertificateNumber": {
-                    "S": "999999999"
-                  },
-                  "certificateLink": {
-                    "S": "CERTIFICATE-LINK"
-                  },
-                  "testExpiryDate": {
-                    "S": "2020-01-01T00:00:00.000Z"
-                  },
-                  "testAnniversaryDate": {
-                    "S": "2020-01-01T00:00:00.000Z"
-                  },
-                  "testTypeStartTimestamp": {
-                    "S": "2020-01-01T00:00:00.023Z"
-                  },
-                  "testTypeEndTimestamp": {
-                    "S": "2020-01-01T00:00:00.000Z"
-                  },
-                  "statusUpdatedFlag": {
-                    "BOOL": true
-                  },
-                  "numberOfSeatbeltsFitted": {
+                  "imNumber": {
                     "N": "1"
                   },
-                  "lastSeatbeltInstallationCheckDate": {
-                    "S": "2020-01-01"
+                  "imDescription": {
+                    "S": "IM-DESCRIPTION"
                   },
-                  "seatbeltInstallationCheckDate": {
-                    "BOOL": true
-                  },
-                  "testResult": {
-                    "S": "fail"
-                  },
-                  "prohibitionIssued": {
-                    "BOOL": true
-                  },
-                  "reasonForAbandoning": {
-                    "S": "REASON-FOR-ABANDONING"
-                  },
-                  "additionalNotesRecorded": {
-                    "S": "ADDITIONAL-NOTES-RECORDED"
-                  },
-                  "additionalCommentsForAbandon": {
-                    "S": "ADDITIONAL-COMMENTS-FOR-ABANDON"
-                  },
-                  "modType": {
+                  "additionalInformation": {
                     "M": {
-                      "code": {
-                        "S": "p"
+                      "location": {
+                        "M": {
+                          "vertical": {
+                            "S": "upper"
+                          },
+                          "horizontal": {
+                            "S": "inner"
+                          },
+                          "lateral": {
+                            "S": "nearside"
+                          },
+                          "longitudinal": {
+                            "S": "front"
+                          },
+                          "rowNumber": {
+                            "N": "1"
+                          },
+                          "seatNumber": {
+                            "N": "1"
+                          },
+                          "axleNumber": {
+                            "N": "1"
+                          }
+                        }
                       },
-                      "description": {
-                        "S": "particulate trap"
+                      "notes": {
+                        "S": "NOTES"
                       }
                     }
                   },
-                  "emissionStandard": {
-                    "S": "0.10 g/kWh Euro 3 PM"
+                  "itemNumber": {
+                    "N": "1"
                   },
-                  "fuelType": {
-                    "S": "diesel"
+                  "itemDescription": {
+                    "S": "ITEM-DESCRIPTION"
                   },
-                  "particulateTrapFitted": {
-                    "S": "PARTICULATE-TRAP-FITTED"
+                  "deficiencyRef": {
+                    "S": "DEFICIENCY-REF"
                   },
-                  "particulateTrapSerialNumber": {
-                    "S": "PARTICULATE-TRAP-SERIAL-NUMBER"
+                  "deficiencyId": {
+                    "S": "a"
                   },
-                  "modificationTypeUsed": {
-                    "S": "MODIFICATION-TYPE-USED"
+                  "deficiencySubId": {
+                    "S": "mdclxvi"
                   },
-                  "smokeTestKLimitApplied": {
-                    "S": "SMOKE-TEST-K-LIMIT-APPLIED"
+                  "deficiencyCategory": {
+                    "S": "advisory"
                   },
-                  "defects": {
-                    "L": [
-                      {
-                        "M": {
-                          "imNumber": {
-                            "N": "1"
-                          },
-                          "imDescription": {
-                            "S": "IM-DESCRIPTION"
-                          },
-                          "additionalInformation": {
-                            "M": {
-                              "location": {
-                                "M": {
-                                  "vertical": {
-                                    "S": "upper"
-                                  },
-                                  "horizontal": {
-                                    "S": "inner"
-                                  },
-                                  "lateral": {
-                                    "S": "nearside"
-                                  },
-                                  "longitudinal": {
-                                    "S": "front"
-                                  },
-                                  "rowNumber": {
-                                    "N": "1"
-                                  },
-                                  "seatNumber": {
-                                    "N": "1"
-                                  },
-                                  "axleNumber": {
-                                    "N": "1"
-                                  }
-                                }
-                              },
-                              "notes": {
-                                "S": "NOTES"
-                              }
-                            }
-                          },
-                          "itemNumber": {
-                            "N": "1"
-                          },
-                          "itemDescription": {
-                            "S": "ITEM-DESCRIPTION"
-                          },
-                          "deficiencyRef": {
-                            "S": "DEFICIENCY-REF"
-                          },
-                          "deficiencyId": {
-                            "S": "a"
-                          },
-                          "deficiencySubId": {
-                            "S": "mdclxvi"
-                          },
-                          "deficiencyCategory": {
-                            "S": "advisory"
-                          },
-                          "deficiencyText": {
-                            "S": "DEFICIENCY-TEXT"
-                          },
-                          "stdForProhibition": {
-                            "BOOL": true
-                          },
-                          "prs": {
-                            "BOOL": true
-                          },
-                          "prohibitionIssued": {
-                            "BOOL": true
-                          }
-                        }
-                      }
-                    ]
+                  "deficiencyText": {
+                    "S": "DEFICIENCY-TEXT"
                   },
-                  "customDefects": {
-                    "L": [
-                      {
-                        "M": {
-                          "referenceNumber": {
-                            "S": "1010101010"
-                          },
-                          "defectName": {
-                            "S": "DEFECT-NAME"
-                          },
-                          "defectNotes": {
-                            "S": "DEFECT-NOTES"
-                          }
-                        }
-                      }
-                    ]
+                  "stdForProhibition": {
+                    "BOOL": true
+                  },
+                  "prs": {
+                    "BOOL": true
+                  },
+                  "prohibitionIssued": {
+                    "BOOL": true
+                  }
+                }
+              }
+            ]
+          },
+          "customDefects": {
+            "L": [
+              {
+                "M": {
+                  "referenceNumber": {
+                    "S": "1010101010"
+                  },
+                  "defectName": {
+                    "S": "DEFECT-NAME"
+                  },
+                  "defectNotes": {
+                    "S": "DEFECT-NOTES"
                   }
                 }
               }


### PR DESCRIPTION
## Description

Update-store is silently discarding test results without a system number. This changes is so it errors and such results will end up  on the DLQ.
The change also includes removing the testResults wrapper around the test json files. They appear to be superfluous and were hindering the code.

Related issue: [CB2-7564](https://dvsa.atlassian.net/browse/CB2-7564)
