### PR TITLE
CB2-7685: Workaround for missing insertId on upserts

### DIFF
--- a/src/functions/process-stream-event.ts
+++ b/src/functions/process-stream-event.ts
@@ -56,7 +56,7 @@ export const processStreamEvent: Handler = async (event: SQSEvent, context: Cont
 
                 debugLog(`DynamoDB ---> Aurora | END   (event ID: ${dynamoRecord.eventID})`);
             } catch (err) {
-                console.error("Couldn't convert DynamoDB entity to Aurora, will return record to SQS for retry", err);
+                console.error("Couldn't convert DynamoDB entity to Aurora, will return record to SQS for retry", [ `messageId: ${id}`, err ]);
                 res.batchItemFailures.push({ itemIdentifier: id });
                 dumpArguments(event, context);
             }

--- a/src/services/table-details.ts
+++ b/src/services/table-details.ts
@@ -382,7 +382,8 @@ export const TEST_RESULT_TABLE: TableDetails = {
         "modificationTypeUsed",
         "smokeTestKLimitApplied",
         "createdBy_Id",
-        "lastUpdatedBy_Id"
+        "lastUpdatedBy_Id",
+        "nopInsertedAt"
     ]
 };
 

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -181,7 +181,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
                         testType.modificationTypeUsed,
                         testType.smokeTestKLimitApplied,
                         createdById,
-                        lastUpdatedById, ,
+                        lastUpdatedById,
                         moment().format("YYYY-MM-DD HH:mm:ss.SSS")
                     ],
                     testResultConnection

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -22,6 +22,7 @@ import {Connection} from "mysql2/promise";
 import {EntityConverter} from "./entity-conversion";
 import {debugLog} from "./logger";
 import { vinCleanser } from "../utils/cleanser";
+import moment from "moment";
 
 export const testResultsConverter = (): EntityConverter<TestResults> => {
     return {
@@ -122,6 +123,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
                         undefined,
                         createdById,
                         lastUpdatedById,
+                        moment().format("YYYY-MM-DD HH:mm:ss.SSS")
                     ],
                     testResultConnection
                 );
@@ -179,7 +181,8 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
                         testType.modificationTypeUsed,
                         testType.smokeTestKLimitApplied,
                         createdById,
-                        lastUpdatedById,
+                        lastUpdatedById, ,
+                        moment().format("YYYY-MM-DD HH:mm:ss.SSS")
                     ],
                     testResultConnection
                 );

--- a/tests/integration/test-results-conversion.intTest.ts
+++ b/tests/integration/test-results-conversion.intTest.ts
@@ -15,6 +15,10 @@ useLocalDb();
 describe("convertTestResults() integration tests", () => {
     let container: StartedTestContainer;
 
+    beforeEach(async () => {
+        jest.restoreAllMocks();
+    });
+
     beforeAll(async () => {
         jest.setTimeout(60_000);
 
@@ -62,6 +66,221 @@ describe("convertTestResults() integration tests", () => {
                 return;
             }
         );
+
+        const vehicleResultSet = await executeSql(
+            `SELECT \`system_number\`, \`vin\`, \`vrm_trm\`, \`trailer_id\`, \`createdAt\`, \`id\`
+             FROM \`vehicle\`
+             WHERE \`vehicle\`.\`id\` IN (
+                SELECT \`id\`
+                FROM \`vehicle\`
+                WHERE \`vehicle\`.\`system_number\` = "SYSTEM-NUMBER"
+             )`
+        );
+
+        expect(vehicleResultSet.rows.length).toEqual(1);
+        expect(vehicleResultSet.rows[0].system_number).toEqual("SYSTEM-NUMBER");
+        expect(vehicleResultSet.rows[0].vin).toEqual("VIN");
+        expect(vehicleResultSet.rows[0].vrm_trm).toEqual("VRM");
+        expect(vehicleResultSet.rows[0].trailer_id).toEqual("88888888");
+        expect((vehicleResultSet.rows[0].createdAt as Date).toUTCString()).not.toBeNull();
+
+        const testResultSet = await executeSql(
+            `SELECT \`test_station_id\`, \`tester_id\`, \`vehicle_class_id\`, \`preparer_id\`, \`createdBy_Id\`, \`lastUpdatedBy_Id\`,
+                    \`fuel_emission_id\`, \`test_type_id\`, \`id\`, \`testResultId\`, \`testCode\`,  \`certificateNumber\`,  \`secondaryCertificateNumber\`,
+                    \`testExpiryDate\`,  \`testAnniversaryDate\`,  \`testTypeStartTimestamp\`,  \`numberOfSeatbeltsFitted\`, \`lastSeatbeltInstallationCheckDate\`,
+                    \`seatbeltInstallationCheckDate\`,  \`testResult\`,  \`reasonForAbandoning\`,  \`additionalNotesRecorded\`,  \`additionalCommentsForAbandon\`,
+                    \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`
+            FROM \`test_result\`
+            WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}`
+        );
+
+        expect(testResultSet.rows[0].testResultId).toEqual("TEST-RESULT-ID");
+        expect(testResultSet.rows.length).toEqual(1);
+        expect(testResultSet.rows[0].testCode).toEqual("333");
+        expect(testResultSet.rows[0].certificateNumber).toEqual("999999999");
+        expect(testResultSet.rows[0].secondaryCertificateNumber).toEqual("999999999");
+        expect((testResultSet.rows[0].testExpiryDate as Date).toISOString()).toEqual("2020-01-01T00:00:00.000Z");
+        expect((testResultSet.rows[0].testAnniversaryDate as Date).toISOString()).toEqual("2020-01-01T00:00:00.000Z");
+        expect((testResultSet.rows[0].testTypeStartTimestamp as Date).toISOString()).toEqual("2020-01-01T00:00:00.023Z");
+        expect(testResultSet.rows[0].lastSeatbeltInstallationCheckDate).toEqual(new Date("2020-01-01"));
+        expect(testResultSet.rows[0].seatbeltInstallationCheckDate).toEqual(1);
+        expect(testResultSet.rows[0].testResult).toEqual("fail");
+        expect(testResultSet.rows[0].reasonForAbandoning).toEqual("REASON-FOR-ABANDONING");
+        expect(testResultSet.rows[0].additionalNotesRecorded).toEqual("ADDITIONAL-NOTES-RECORDED");
+        expect(testResultSet.rows[0].particulateTrapFitted).toEqual("PARTICULATE-TRAP-FITTED");
+        expect(testResultSet.rows[0].particulateTrapSerialNumber).toEqual("PARTICULATE-TRAP-SERIAL-NUMBER");
+        expect(testResultSet.rows[0].modificationTypeUsed).toEqual("MODIFICATION-TYPE-USED");
+        expect(testResultSet.rows[0].smokeTestKLimitApplied).toEqual("SMOKE-TEST-K-LIMIT-APPLIED");
+
+        expect(testResultSet.rows.length).toEqual(1);
+
+        const { test_station_id, tester_id, vehicle_class_id, preparer_id, createdBy_Id, lastUpdatedBy_Id, fuel_emission_id, test_type_id, id } = testResultSet.rows[0];
+
+        const testStationResultSet = await executeSql(
+            `SELECT \`pNumber\`, \`name\`, \`type\`
+             FROM \`test_station\`
+             WHERE \`test_station\`.\`id\` = ${test_station_id}`
+        );
+        expect(testStationResultSet.rows.length).toEqual(1);
+        expect(testStationResultSet.rows[0].pNumber).toEqual("P-NUMBER");
+        expect(testStationResultSet.rows[0].name).toEqual("TEST-STATION-NAME");
+        expect(testStationResultSet.rows[0].type).toEqual("atf");
+
+        const testerResultSet = await executeSql(
+            `SELECT \`staffId\`, \`name\`, \`email_address\`
+             FROM \`tester\`
+             WHERE \`tester\`.\`id\` = ${tester_id}`
+        );
+        expect(testerResultSet.rows.length).toEqual(1);
+        expect(testerResultSet.rows[0].staffId).toEqual("999999999");
+        expect(testerResultSet.rows[0].name).toEqual("TESTER-NAME");
+        expect(testerResultSet.rows[0].email_address).toEqual("TESTER-EMAIL-ADDRESS");
+
+        const vehicleClassResultSet = await executeSql(
+            `SELECT \`code\`,
+                    \`description\`,
+                    \`vehicleType\`,
+                    \`vehicleSize\`,
+                    \`vehicleConfiguration\`,
+                    \`euVehicleCategory\`
+             FROM \`vehicle_class\`
+             WHERE \`vehicle_class\`.\`id\` = ${vehicle_class_id}`
+        );
+        expect(vehicleClassResultSet.rows.length).toEqual(1);
+        expect(vehicleClassResultSet.rows[0].code).toEqual("2");
+        expect(vehicleClassResultSet.rows[0].description).toEqual("motorbikes over 200cc or with a sidecar");
+        expect(vehicleClassResultSet.rows[0].vehicleType).toEqual("psv");
+        expect(vehicleClassResultSet.rows[0].vehicleSize).toEqual("large");
+        expect(vehicleClassResultSet.rows[0].vehicleConfiguration).toEqual("rigid");
+        expect(vehicleClassResultSet.rows[0].euVehicleCategory).toEqual("m1");
+
+        const preparerResultSet = await executeSql(
+            `SELECT \`preparerId\`, \`name\`
+             FROM \`preparer\`
+             WHERE \`preparer\`.\`id\` = ${preparer_id}`
+        );
+        expect(preparerResultSet.rows.length).toEqual(1);
+        expect(preparerResultSet.rows[0].preparerId).toEqual("999999999");
+        expect(preparerResultSet.rows[0].name).toEqual("PREPARER-NAME");
+
+        const createdByResultSet = await executeSql(
+            `SELECT \`identityId\`, \`name\`
+             FROM \`identity\`
+             WHERE \`identity\`.\`id\` = ${createdBy_Id}`
+        );
+        expect(createdByResultSet.rows.length).toEqual(1);
+        expect(createdByResultSet.rows[0].identityId).toEqual("CREATED-BY-ID");
+        expect(createdByResultSet.rows[0].name).toEqual("CREATED-BY-NAME");
+
+        const lastUpdatedByResultSet = await executeSql(
+            `SELECT \`identityId\`, \`name\`
+             FROM \`identity\`
+             WHERE \`identity\`.\`id\` = ${lastUpdatedBy_Id}`
+        );
+        expect(lastUpdatedByResultSet.rows.length).toEqual(1);
+        expect(lastUpdatedByResultSet.rows[0].identityId).toEqual("LAST-UPDATED-BY-ID");
+        expect(lastUpdatedByResultSet.rows[0].name).toEqual("LAST-UPDATED-BY-NAME");
+
+        const fuelEmissionResultSet = await executeSql(
+            `SELECT \`modTypeCode\`, \`description\`, \`emissionStandard\`, \`fuelType\`
+             FROM \`fuel_emission\`
+             WHERE \`fuel_emission\`.\`id\` = ${fuel_emission_id}`
+        );
+        expect(fuelEmissionResultSet.rows.length).toEqual(1);
+        expect(fuelEmissionResultSet.rows[0].modTypeCode).toEqual("p");
+        expect(fuelEmissionResultSet.rows[0].description).toEqual("particulate trap");
+        expect(fuelEmissionResultSet.rows[0].emissionStandard).toEqual("0.10 g/kWh Euro 3 PM");
+        expect(fuelEmissionResultSet.rows[0].fuelType).toEqual("diesel");
+
+        const testTypeResultSet = await executeSql(
+            `SELECT \`testTypeClassification\`, \`testTypeName\`
+             FROM \`test_type\`
+             WHERE \`test_type\`.\`id\` = ${test_type_id}`
+        );
+        expect(testTypeResultSet.rows.length).toEqual(1);
+        expect(testTypeResultSet.rows[0].testTypeClassification).toEqual("2323232323232323232323");
+        expect(testTypeResultSet.rows[0].testTypeName).toEqual("TEST-TYPE-NAME");
+
+        const testDefectResultSet = await executeSql(
+            `SELECT \`test_result_id\`, \`defect_id\`, \`location_id\`, \`notes\`, \`prs\`, \`prohibitionIssued\`
+             FROM \`test_defect\`
+             WHERE \`test_defect\`.\`test_result_id\` = ${id}`
+        );
+
+        const testDefectLastIndex = testDefectResultSet.rows.length - 1;
+
+        expect(testDefectResultSet.rows[testDefectLastIndex].test_result_id).toEqual(id);
+        expect(testDefectResultSet.rows[testDefectLastIndex].defect_id).toEqual(1);
+        expect(testDefectResultSet.rows[testDefectLastIndex].location_id).toEqual(1);
+        expect(testDefectResultSet.rows[testDefectLastIndex].notes).toEqual("NOTES");
+        expect(testDefectResultSet.rows[testDefectLastIndex].prs).toEqual(1);
+        expect(testDefectResultSet.rows[testDefectLastIndex].prohibitionIssued).toEqual(1);
+
+        const defectResultSet = await executeSql(
+            `SELECT \`imNumber\`,
+                    \`imDescription\`,
+                    \`itemNumber\`,
+                    \`itemDescription\`,
+                    \`deficiencyRef\`,
+                    \`deficiencyId\`,
+                    \`deficiencySubId\`,
+                    \`deficiencyCategory\`,
+                    \`deficiencyText\`,
+                    \`stdForProhibition\`
+             FROM \`defect\`
+             WHERE \`defect\`.\`id\` = ${testDefectResultSet.rows[testDefectLastIndex].defect_id}`
+        );
+        expect(defectResultSet.rows.length).toEqual(1);
+        expect(defectResultSet.rows[0].imNumber).toEqual(1);
+        expect(defectResultSet.rows[0].imDescription).toEqual("IM-DESCRIPTION");
+        expect(defectResultSet.rows[0].itemNumber).toEqual(1);
+        expect(defectResultSet.rows[0].itemDescription).toEqual("ITEM-DESCRIPTION");
+        expect(defectResultSet.rows[0].deficiencyRef).toEqual("DEFICIENCY-REF");
+        expect(defectResultSet.rows[0].deficiencyId).toEqual("a");
+        expect(defectResultSet.rows[0].deficiencySubId).toEqual("mdclxvi");
+        expect(defectResultSet.rows[0].deficiencyCategory).toEqual("advisory");
+        expect(defectResultSet.rows[0].deficiencyText).toEqual("DEFICIENCY-TEXT");
+        expect(defectResultSet.rows[0].itemNumber).toEqual(1);
+
+        const customDefectResultSet = await executeSql(
+            `SELECT \`test_result_id\`, \`referenceNumber\`, \`defectName\`, \`defectNotes\`
+             FROM \`custom_defect\`
+             WHERE \`custom_defect\`.\`test_result_id\` = ${id}`
+        );
+
+        const customDefectLastIndex = customDefectResultSet.rows.length - 1;
+
+        expect(customDefectResultSet.rows[customDefectLastIndex].test_result_id).toEqual(id);
+        expect(customDefectResultSet.rows[customDefectLastIndex].referenceNumber).toEqual("1010101010");
+        expect(customDefectResultSet.rows[customDefectLastIndex].defectName).toEqual("DEFECT-NAME");
+        expect(customDefectResultSet.rows[customDefectLastIndex].defectNotes).toEqual("DEFECT-NOTES");
+    });
+
+    it("should correctly convert a DynamoDB event into Aurora rows when processed a second time", async () => {
+        const event = {
+            Records: [
+                {
+                    body: JSON.stringify({
+                        eventSourceARN: "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+                        eventName: "INSERT",
+                        dynamodb: {
+                            NewImage: testResultsJson
+                        }
+                    })
+                }
+            ]
+        };
+
+        const consoleSpy = jest.spyOn(global.console, "error");
+        await processStreamEvent(
+            event,
+            exampleContext(),
+            () => {
+                return;
+            }
+        );
+
+        expect(consoleSpy).toBeCalledTimes(0);
 
         const vehicleResultSet = await executeSql(
             `SELECT \`system_number\`, \`vin\`, \`vrm_trm\`, \`trailer_id\`, \`createdAt\`, \`id\`
@@ -485,7 +704,6 @@ describe("convertTestResults() integration tests", () => {
     });
 
     it("A new Test Result with two TestTypes is inserted correctly", async () => {
-
         const event = {
             Records: [
                 {
@@ -718,8 +936,8 @@ describe("convertTestResults() integration tests", () => {
         expect(customDefectResultSet.rows[customDefectLastIndex].defectNotes).toEqual("DEFECT-NOTES");
 
     });
-    it("A new Test Result with no systemNumber throws an error", async () => {
 
+    it("A new Test Result with no systemNumber throws an error", async () => {
         const event = {
             Records: [
                 {
@@ -909,7 +1127,6 @@ describe("convertTestResults() integration tests", () => {
              WHERE \`test_type\`.\`id\` = ${test_type_id}`
         );
         expect(testTypeResultSet.rows.length).toEqual(0);
-
 
         const testDefectResultSet = await executeSql(
             `SELECT \`test_result_id\`, \`defect_id\`, \`location_id\`, \`notes\`, \`prs\`, \`prohibitionIssued\`

--- a/tests/integration/test-results-conversion.intTest.ts
+++ b/tests/integration/test-results-conversion.intTest.ts
@@ -752,7 +752,7 @@ describe("convertTestResults() integration tests", () => {
         expect(consoleSpy).nthCalledWith(
             1,
             "Couldn't convert DynamoDB entity to Aurora, will return record to SQS for retry",
-            new Error("result is missing required field 'systemNumber'")
+            ["messageId: faf41ab1-5b42-462c-b242-c4450e15c724", new Error("result is missing required field 'systemNumber'")]
         );
     });
 


### PR DESCRIPTION
## Description

The test_result table has a trigger that populates the testtype_version table. It has been found that it can affect the identity returned to the update store lambda.

The issue only arises when: 

- A result is processed for the second time and results in an update rather than an insert.
and
- The test_result does not differ in any anyway to the record being updated.

Related issue: [CB2-7685](https://dvsa.atlassian.net/browse/CB2-7685)
Related PR: [cvs-nop/pull/14](https://github.com/dvsa/cvs-nop/pull/14)

## Evidence of completion
In the absence of a fix or understanding of the behaviour, a workaround has been implemented which involves inserting a timestamp along with the rest of the test_result data.
### Before workaround
First upsert
![image](https://user-images.githubusercontent.com/13391709/222709314-2b2b75f3-0aa6-4e7e-a71f-59fe9a9b3087.png)
Second upsert
![image](https://user-images.githubusercontent.com/13391709/222709543-60f243e7-1125-452b-96c0-60fe7927e872.png)
### After workaround
First upsert
![image](https://user-images.githubusercontent.com/13391709/222710124-bd8de9fd-53e5-4cfe-be95-f2f2e44555b0.png)
Second upsert
![image](https://user-images.githubusercontent.com/13391709/222710385-05274082-d62c-4d8c-8944-84f54384f949.png)
Data in the database
![image](https://user-images.githubusercontent.com/13391709/222710327-200190ef-f5be-4839-be89-b3c024644c2f.png)

