### PR TITLE
Feature/cb2 10594

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ For the full field-to-column mapping, see `tech-record-document-conversion.ts`.
   * `microfilm`
   * `plate`
   * `axle`
+  * `adr_details`
+  * `adr_memos_apply`
+  * `adr_permitted_dangerous_goods`
+  * `adr_productListUnNo`
+  * `adr_additional_examiner_notes`
+  * `adr_additional_notes_number`
+
 
 ## Test Result conversion
 For the full field-to-column mapping, see `test-result-record-conversion.ts`.

--- a/src/models/adr-certificate-details.ts
+++ b/src/models/adr-certificate-details.ts
@@ -1,0 +1,49 @@
+import { DynamoDbImage } from "../services/dynamodb-images";
+import { Maybe } from "./optionals";
+
+// define AdrCertificateDetails' high-level attributes data types
+export interface AdrCertificateDetails {
+    adrPassCertificateDetails?: AdrPassCertificateDetails;
+}
+
+// define Enums
+export type certificateIdEnum = "PASS" | "REPLACEMENT"
+
+// define AdrCertificateDetails' sub-attributes data types 
+export type AdrPassCertificateDetails = AdrPassCertificateDetailsItems[];
+
+export interface AdrPassCertificateDetailsItems {
+    createdByName?: string;
+    certificateType?: string;
+    generatedTimestamp?: string;
+    certificateId?: string;
+  }
+
+// function to parse AdrCertificateDetails' high-level and sub attributes + return AdrCertificateDetails object
+export const parseAdrCertificateDetails = (
+    certificateDetails?: DynamoDbImage
+  ): Maybe<AdrCertificateDetails> => {
+    if (!certificateDetails) {
+      return undefined;
+    }
+
+    const adrPassCertificateDetailsImage: DynamoDbImage = certificateDetails.getList(
+        "adrPassCertificateDetails"
+    )!;
+    const adrPassCertificateDetails: AdrPassCertificateDetails = [];
+
+    for (const key of adrPassCertificateDetailsImage.getKeys()) {
+        const adrPassCertificateDetailsItemImage = adrPassCertificateDetailsImage.getMap(key)!;
+        adrPassCertificateDetails.push({
+        createdByName: adrPassCertificateDetailsItemImage.getString("createdByName"),
+        certificateType: adrPassCertificateDetailsItemImage.getString("certificateType"),
+        generatedTimestamp: adrPassCertificateDetailsItemImage.getString("generatedTimestamp"),
+        certificateId: adrPassCertificateDetailsItemImage.getString("certificateId") as certificateIdEnum,
+        });
+    }
+
+
+  return {
+    adrPassCertificateDetails
+  };
+};

--- a/src/models/adr-certificate-details.ts
+++ b/src/models/adr-certificate-details.ts
@@ -7,9 +7,9 @@ export interface AdrCertificateDetails {
 }
 
 // define Enums
-export type certificateIdEnum = "PASS" | "REPLACEMENT"
+export type certificateIdEnum = "PASS" | "REPLACEMENT";
 
-// define AdrCertificateDetails' sub-attributes data types 
+// define AdrCertificateDetails' sub-attributes data types
 export type AdrPassCertificateDetails = AdrPassCertificateDetailsItems[];
 
 export interface AdrPassCertificateDetailsItems {
@@ -41,9 +41,7 @@ export const parseAdrCertificateDetails = (
         certificateId: adrPassCertificateDetailsItemImage.getString("certificateId") as certificateIdEnum,
         });
     }
-
-
-  return {
-    adrPassCertificateDetails
-  };
+    return {
+      adrPassCertificateDetails
+    };
 };

--- a/src/models/adr-certificate-details.ts
+++ b/src/models/adr-certificate-details.ts
@@ -7,7 +7,9 @@ export interface AdrCertificateDetails {
 }
 
 // define Enums
-export type certificateIdEnum = "PASS" | "REPLACEMENT";
+export type certificateIdEnum =
+  | "PASS"
+  | "REPLACEMENT";
 
 // define AdrCertificateDetails' sub-attributes data types
 export type AdrPassCertificateDetails = AdrPassCertificateDetailsItems[];

--- a/src/models/adr-details.ts
+++ b/src/models/adr-details.ts
@@ -44,6 +44,8 @@ export type compatibilityGroupJEnum = "I" | "E"
 
 export type additionalNotesNumberEnum =  "1" | "1A" | "2" | "3" | "V1B" | "T1B"
 
+export type additionalNotesguidanceNotesEnum =  "New certificate requested" | "M145 Statement"
+
 export type substancesPermittedEnum = "Substances permitted under the tank code and any special provisions specified in 9 may be carried" |
                                       "Substances (Class UN number and if necessary packing group and proper shipping name) may be carried"
 
@@ -73,7 +75,7 @@ export interface ApplicantDetails {
 
 export interface AdditionalNotes {
   number?: additionalNotesNumberEnum[];
-  // guidanceNotes?: string[];
+  guidanceNotes?: additionalNotesguidanceNotesEnum[];
 }
 
 export interface Tank {
@@ -129,9 +131,9 @@ export const parseAdrDetails = (
   )!;
   const additionalNotes: AdditionalNotes = {
     number: parseStringArray(additionalNotesImage.getList("number")) as additionalNotesNumberEnum[],
-    // guidanceNotes: parseStringArray(
-    //   additionalNotesImage.getList("guidanceNotes")
-    // ),
+    guidanceNotes: parseStringArray(
+      additionalNotesImage.getList("guidanceNotes")
+    ) as additionalNotesguidanceNotesEnum[],
   };
 
   const applicantDetailsImage: DynamoDbImage = adrDetails.getMap(

--- a/src/models/adr-details.ts
+++ b/src/models/adr-details.ts
@@ -11,13 +11,13 @@ export interface AdrDetails {
   brakeDeclarationIssuer?: string;
   brakeEndurance?: boolean;
   weight?: number;
-  compatibilityGroupJ?: string;
+  compatibilityGroupJ?: compatibilityGroupJEnum;
   documents?: string[];
-  permittedDangerousGoods?: string[];
+  permittedDangerousGoods?: permittedDangerousGoodsEnum[];
   additionalExaminerNotes?: AdditionalExaminerNotes;
   applicantDetails?: ApplicantDetails;
   dangerousGoods?: boolean;
-  memosApply?: string[];
+  memosApply?: memosApplyEnum[];
   m145?: boolean;
   additionalNotes?: AdditionalNotes;
   adrTypeApprovalNo?: string;
@@ -26,33 +26,35 @@ export interface AdrDetails {
 }
 
 // define Enums
-export type VehicleDetailsTypeEnum = "Artic tractor" | "Rigid box body" | "Rigid sheeted load" | "Rigid tank" | 
-                                 "Rigid skeletal" | "Rigid battery" | "Full drawbar box body" | 
-                                 "Full drawbar sheeted load" | "Full drawbar tank" | "Full drawbar skeletal" | 
-                                 "Full drawbar battery" | "Centre axle box body" | "Centre axle sheeted load" | 
-                                 "Centre axle tank" | "Centre axle skeletal" | "Centre axle battery" | 
-                                 "Semi trailer box body" | "Semi trailer sheeted load" | "Semi trailer tank" | 
-                                 "Semi trailer skeletal" | "Semi trailer battery Enum"
+export type VehicleDetailsTypeEnum = "Artic tractor" | "Rigid box body" | "Rigid sheeted load" | "Rigid tank" |
+                                 "Rigid skeletal" | "Rigid battery" | "Full drawbar box body" |
+                                 "Full drawbar sheeted load" | "Full drawbar tank" | "Full drawbar skeletal" |
+                                 "Full drawbar battery" | "Centre axle box body" | "Centre axle sheeted load" |
+                                 "Centre axle tank" | "Centre axle skeletal" | "Centre axle battery" |
+                                 "Semi trailer box body" | "Semi trailer sheeted load" | "Semi trailer tank" |
+                                 "Semi trailer skeletal" | "Semi trailer battery Enum";
 
 export type Tc2TypeEnum = "initial";
 
 export type Tc3TypeEnum = "intermediate" | "periodic" | "exceptional";
 
 export type permittedDangerousGoodsEnum = "FP <61 (FL)" | "AT" | "Class 5.1 Hydrogen Peroxide (OX)" | "MEMU" |
-                                          "Carbon Disulphide" | "Hydrogen" | "Explosives (type 2)" | "Explosives (type 3)"
+                                          "Carbon Disulphide" | "Hydrogen" | "Explosives (type 2)" | "Explosives (type 3)";
 
-export type compatibilityGroupJEnum = "I" | "E"
+export type compatibilityGroupJEnum = "I" | "E";
 
-export type additionalNotesNumberEnum =  "1" | "1A" | "2" | "3" | "V1B" | "T1B"
+export type additionalNotesNumberEnum =  "1" | "1A" | "2" | "3" | "V1B" | "T1B";
 
 // export type additionalNotesguidanceNotesEnum =  "New certificate requested" | "M145 Statement"
 
 export type substancesPermittedEnum = "Substances permitted under the tank code and any special provisions specified in 9 may be carried" |
-                                      "Substances (Class UN number and if necessary packing group and proper shipping name) may be carried"
+                                      "Substances (Class UN number and if necessary packing group and proper shipping name) may be carried";
 
-export type memosApplyEnum = "07/09 3mth leak ext"
+export type memosApplyEnum = "07/09 3mth leak ext";
 
-// define AdrDetails' sub-attributes data types 
+export type tankStatementSelectEnum = "Statement" | "Product list";
+
+// define AdrDetails' sub-attributes data types
 export interface VehicleDetails {
   type?: VehicleDetailsTypeEnum;
   approvalDate?: string;
@@ -96,8 +98,8 @@ export interface TankDetails {
 }
 
 export interface TankStatement {
-  substancesPermitted?: string;
-  select?: string;
+  select?: tankStatementSelectEnum;
+  substancesPermitted?: substancesPermittedEnum;
   statement?: string;
   productListRefNo?: string;
   productListUnNo?: string[];
@@ -119,7 +121,7 @@ export interface Tc3DetailsItem {
   tc3PeriodicExpiryDate?: string;
 }
 
-// function to parse AdrDetails' high-level and sub attributes + return AdrDetails object 
+// function to parse AdrDetails' high-level and sub attributes + return AdrDetails object
 export const parseAdrDetails = (
   adrDetails?: DynamoDbImage
 ): Maybe<AdrDetails> => {
@@ -203,7 +205,7 @@ export const parseAdrDetails = (
   const tankStatementImage: DynamoDbImage = tankImage.getMap("tankStatement")!;
   const tankStatement: TankStatement = {
     substancesPermitted: tankStatementImage.getString("substancesPermitted") as substancesPermittedEnum,
-    select: tankStatementImage.getString("select"),
+    select: tankStatementImage.getString("select") as tankStatementSelectEnum,
     statement: tankStatementImage.getString("statement"),
     productListRefNo: tankStatementImage.getString("productListRefNo"),
     productListUnNo: parseStringArray(
@@ -230,7 +232,7 @@ export const parseAdrDetails = (
       createdAtDate: additionalExaminerNotesItemImage.getString("createdAtDate"),
       lastUpdatedBy: additionalExaminerNotesItemImage.getString("lastUpdatedBy"),
     });
-  };
+  }
 
 
   return {
@@ -247,7 +249,7 @@ export const parseAdrDetails = (
     permittedDangerousGoods: parseStringArray(
       adrDetails.getList("permittedDangerousGoods")
     ) as permittedDangerousGoodsEnum[],
-    additionalExaminerNotes: additionalExaminerNotes,
+    additionalExaminerNotes,
     applicantDetails,
     dangerousGoods: adrDetails.getBoolean("dangerousGoods"),
     memosApply: parseStringArray(adrDetails.getList("memosApply")) as memosApplyEnum[],

--- a/src/models/adr-details.ts
+++ b/src/models/adr-details.ts
@@ -26,33 +26,69 @@ export interface AdrDetails {
 }
 
 // define Enums
-export type VehicleDetailsTypeEnum = "Artic tractor" | "Rigid box body" | "Rigid sheeted load" | "Rigid tank" |
-                                 "Rigid skeletal" | "Rigid battery" | "Full drawbar box body" |
-                                 "Full drawbar sheeted load" | "Full drawbar tank" | "Full drawbar skeletal" |
-                                 "Full drawbar battery" | "Centre axle box body" | "Centre axle sheeted load" |
-                                 "Centre axle tank" | "Centre axle skeletal" | "Centre axle battery" |
-                                 "Semi trailer box body" | "Semi trailer sheeted load" | "Semi trailer tank" |
-                                 "Semi trailer skeletal" | "Semi trailer battery Enum";
+export type VehicleDetailsTypeEnum =
+  | "Artic tractor"
+  | "Rigid box body"
+  | "Rigid sheeted load"
+  | "Rigid tank"
+  | "Rigid skeletal"
+  | "Rigid battery"
+  | "Full drawbar box body"
+  | "Full drawbar sheeted load"
+  | "Full drawbar tank"
+  | "Full drawbar skeletal"
+  | "Full drawbar battery"
+  | "Centre axle box body"
+  | "Centre axle sheeted load"
+  | "Centre axle tank"
+  | "Centre axle skeletal"
+  | "Centre axle battery"
+  | "Semi trailer box body"
+  | "Semi trailer sheeted load"
+  | "Semi trailer tank"
+  | "Semi trailer skeletal"
+  | "Semi trailer battery Enum";
 
 export type Tc2TypeEnum = "initial";
 
-export type Tc3TypeEnum = "intermediate" | "periodic" | "exceptional";
+export type Tc3TypeEnum =
+  | "intermediate"
+  | "periodic"
+  | "exceptional";
 
-export type permittedDangerousGoodsEnum = "FP <61 (FL)" | "AT" | "Class 5.1 Hydrogen Peroxide (OX)" | "MEMU" |
-                                          "Carbon Disulphide" | "Hydrogen" | "Explosives (type 2)" | "Explosives (type 3)";
+export type permittedDangerousGoodsEnum =
+  | "FP <61 (FL)"
+  | "AT"
+  | "Class 5.1 Hydrogen Peroxide (OX)"
+  | "MEMU"
+  | "Carbon Disulphide"
+  | "Hydrogen"
+  | "Explosives (type 2)"
+  | "Explosives (type 3)";
 
-export type compatibilityGroupJEnum = "I" | "E";
+export type compatibilityGroupJEnum =
+  | "I"
+  | "E";
 
-export type additionalNotesNumberEnum =  "1" | "1A" | "2" | "3" | "V1B" | "T1B";
+export type additionalNotesNumberEnum =
+  | "1"
+  | "1A"
+  | "2"
+  | "3"
+  | "V1B"
+  | "T1B";
 
 // export type additionalNotesguidanceNotesEnum =  "New certificate requested" | "M145 Statement"
 
-export type substancesPermittedEnum = "Substances permitted under the tank code and any special provisions specified in 9 may be carried" |
-                                      "Substances (Class UN number and if necessary packing group and proper shipping name) may be carried";
+export type substancesPermittedEnum =
+  | "Substances permitted under the tank code and any special provisions specified in 9 may be carried"
+  | "Substances (Class UN number and if necessary packing group and proper shipping name) may be carried";
 
 export type memosApplyEnum = "07/09 3mth leak ext";
 
-export type tankStatementSelectEnum = "Statement" | "Product list";
+export type tankStatementSelectEnum =
+  | "Statement"
+  | "Product list";
 
 // define AdrDetails' sub-attributes data types
 export interface VehicleDetails {

--- a/src/models/adr-details.ts
+++ b/src/models/adr-details.ts
@@ -84,7 +84,7 @@ export type substancesPermittedEnum =
   | "Substances permitted under the tank code and any special provisions specified in 9 may be carried"
   | "Substances (Class UN number and if necessary packing group and proper shipping name) may be carried";
 
-export type memosApplyEnum = "07/09 3mth leak ext";
+export type memosApplyEnum = "07/09 3mth leak ext ";
 
 export type tankStatementSelectEnum =
   | "Statement"

--- a/src/models/adr-details.ts
+++ b/src/models/adr-details.ts
@@ -18,6 +18,7 @@ export interface AdrDetails {
   applicantDetails?: ApplicantDetails;
   dangerousGoods?: boolean;
   memosApply?: string[];
+  m145?: boolean;
   additionalNotes?: AdditionalNotes;
   adrTypeApprovalNo?: string;
   adrCertificateNotes?: string;
@@ -44,7 +45,7 @@ export type compatibilityGroupJEnum = "I" | "E"
 
 export type additionalNotesNumberEnum =  "1" | "1A" | "2" | "3" | "V1B" | "T1B"
 
-export type additionalNotesguidanceNotesEnum =  "New certificate requested" | "M145 Statement"
+// export type additionalNotesguidanceNotesEnum =  "New certificate requested" | "M145 Statement"
 
 export type substancesPermittedEnum = "Substances permitted under the tank code and any special provisions specified in 9 may be carried" |
                                       "Substances (Class UN number and if necessary packing group and proper shipping name) may be carried"
@@ -75,7 +76,7 @@ export interface ApplicantDetails {
 
 export interface AdditionalNotes {
   number?: additionalNotesNumberEnum[];
-  guidanceNotes?: additionalNotesguidanceNotesEnum[];
+  // guidanceNotes?: additionalNotesguidanceNotesEnum[];
 }
 
 export interface Tank {
@@ -131,9 +132,9 @@ export const parseAdrDetails = (
   )!;
   const additionalNotes: AdditionalNotes = {
     number: parseStringArray(additionalNotesImage.getList("number")) as additionalNotesNumberEnum[],
-    guidanceNotes: parseStringArray(
-      additionalNotesImage.getList("guidanceNotes")
-    ) as additionalNotesguidanceNotesEnum[],
+    // guidanceNotes: parseStringArray(
+    //   additionalNotesImage.getList("guidanceNotes")
+    // ) as additionalNotesguidanceNotesEnum[],
   };
 
   const applicantDetailsImage: DynamoDbImage = adrDetails.getMap(
@@ -250,6 +251,7 @@ export const parseAdrDetails = (
     applicantDetails,
     dangerousGoods: adrDetails.getBoolean("dangerousGoods"),
     memosApply: parseStringArray(adrDetails.getList("memosApply")) as memosApplyEnum[],
+    m145: adrDetails.getBoolean("m145"),
     additionalNotes,
     adrTypeApprovalNo: adrDetails.getString("adrTypeApprovalNo"),
     adrCertificateNotes: adrDetails.getString("adrCertificateNotes"),

--- a/src/models/adr-details.ts
+++ b/src/models/adr-details.ts
@@ -48,7 +48,7 @@ export type VehicleDetailsTypeEnum =
   | "Semi trailer sheeted load"
   | "Semi trailer tank"
   | "Semi trailer skeletal"
-  | "Semi trailer battery Enum";
+  | "Semi trailer battery";
 
 export type Tc2TypeEnum = "initial";
 

--- a/src/models/adr-details.ts
+++ b/src/models/adr-details.ts
@@ -11,6 +11,7 @@ export interface AdrDetails {
   brakeDeclarationIssuer?: string;
   brakeEndurance?: boolean;
   weight?: number;
+  newCertificateRequested?: boolean;
   compatibilityGroupJ?: compatibilityGroupJEnum;
   documents?: string[];
   permittedDangerousGoods?: permittedDangerousGoodsEnum[];
@@ -18,7 +19,7 @@ export interface AdrDetails {
   applicantDetails?: ApplicantDetails;
   dangerousGoods?: boolean;
   memosApply?: memosApplyEnum[];
-  m145?: boolean;
+  m145Statement?: boolean;
   additionalNotes?: AdditionalNotes;
   adrTypeApprovalNo?: string;
   adrCertificateNotes?: string;
@@ -280,6 +281,7 @@ export const parseAdrDetails = (
     brakeDeclarationIssuer: adrDetails.getString("brakeDeclarationIssuer"),
     brakeEndurance: adrDetails.getBoolean("brakeEndurance"),
     weight: adrDetails.getNumber("weight"),
+    newCertificateRequested: adrDetails.getBoolean("newCertificateRequested"),
     compatibilityGroupJ: adrDetails.getString("compatibilityGroupJ") as compatibilityGroupJEnum,
     documents: parseStringArray(adrDetails.getList("documents")),
     permittedDangerousGoods: parseStringArray(
@@ -289,7 +291,7 @@ export const parseAdrDetails = (
     applicantDetails,
     dangerousGoods: adrDetails.getBoolean("dangerousGoods"),
     memosApply: parseStringArray(adrDetails.getList("memosApply")) as memosApplyEnum[],
-    m145: adrDetails.getBoolean("m145"),
+    m145Statement: adrDetails.getBoolean("m145Statement"),
     additionalNotes,
     adrTypeApprovalNo: adrDetails.getString("adrTypeApprovalNo"),
     adrCertificateNotes: adrDetails.getString("adrCertificateNotes"),

--- a/src/models/tech-record.ts
+++ b/src/models/tech-record.ts
@@ -14,7 +14,8 @@ import { Microfilm, parseMicrofilm } from "./microfilm";
 import { parsePlates, Plates } from "./plates";
 import { BodyType, parseBodyType } from "./body-type";
 import { Dimensions, parseDimensions } from "./dimensions";
-import { AdrDetails } from "./adr-details";
+import { AdrDetails, parseAdrDetails } from "./adr-details";
+import { AdrCertificateDetails, parseAdrCertificateDetails } from "./adr-certificate-details";
 import { parseVehicleClass, VehicleClass } from "./vehicle-class";
 import { Brakes, parseBrakes } from "./brakes";
 import { Axles, parseAxles } from "./axles";
@@ -114,6 +115,7 @@ export interface TechRecord {
   noOfAxles?: number;
   brakeCode?: string;
   adrDetails?: AdrDetails;
+  adrCertificateDetails?: AdrCertificateDetails;
   createdByName?: string;
   createdById?: string;
   lastUpdatedByName?: string;
@@ -270,7 +272,8 @@ const parseTechRecord = (image: DynamoDbImage): TechRecord => {
     notes: image.getString("notes"),
     noOfAxles: image.getNumber("noOfAxles"),
     brakeCode: image.getString("brakeCode"),
-    adrDetails: undefined, // intentional - not implemented. parseAdrDetails(image.getMap("adrDetails"))
+    adrDetails: parseAdrDetails(image.getMap("adrDetails")),
+    adrCertificateDetails: parseAdrCertificateDetails(image.getMap("certificateDetails")),
     createdByName: image.getString("createdByName"),
     createdById: image.getString("createdById"),
     lastUpdatedByName: image.getString("lastUpdatedByName"),

--- a/src/services/table-details.ts
+++ b/src/services/table-details.ts
@@ -369,11 +369,6 @@ export const ADR_ADDITIONAL_EXAMINER_NOTES_TABLE: TableDetails = {
   columnNames: ["adr_details_id", "note", "createdAtDate", "lastUpdatedBy"],
 };
 
-export const ADR_ADDITIONAL_NOTES_GUIDANCE_TABLE: TableDetails = {
-  tableName: "adr_additional_notes_guidance",
-  columnNames: ["guidanceNotes", "adr_details_id"],
-};
-
 export const ADR_ADDITIONAL_NOTES_NUMBER_TABLE: TableDetails = {
   tableName: "adr_additional_notes_number",
   columnNames: ["number", "adr_details_id"],
@@ -398,13 +393,12 @@ export const ADR_DETAILS_TABLE: TableDetails = {
     "brakeEndurance",
     "weight",
     "compatibilityGroupJ",
-    "additionalExaminerNotes",
+    // dangerousGoods,
     "applicantDetailsName",
     "street",
     "town",
     "city",
     "postcode",
-    "memosApply",
     "adrTypeApprovalNo",
     "adrCertificateNotes",
     "tankManufacturer",
@@ -417,9 +411,13 @@ export const ADR_DETAILS_TABLE: TableDetails = {
     "tc2IntermediateApprovalNo",
     "tc2IntermediateExpiryDate",
     "substancesPermitted",
+    // "select",
     "statement",
     "productListRefNo",
     "productList",
+    "m145Statement",
+    // "newCertificateRequested",
+
   ],
 };
 
@@ -428,9 +426,14 @@ export const ADR_MEMOS_APPLY_TABLE: TableDetails = {
   columnNames: ["adr_details_id", "memo"],
 };
 
+export const ADR_TANK_DOCUMENTS_TABLE: TableDetails = {
+  tableName: "adr_documents",
+  columnNames: ["adr_details_id", "document"],
+};
+
 export const ADR_PERMITTED_DANGEROUS_GOODS_TABLE: TableDetails = {
   tableName: "adr_permitted_dangerous_goods",
-  columnNames: ["adr_details_id", "dangerous_goods_id"],
+  columnNames: ["adr_details_id", "adr_dangerous_goods_list_id"],
 };
 
 export const ADR_PRODUCTLISTUNNO_LIST_TABLE: TableDetails = {
@@ -440,7 +443,7 @@ export const ADR_PRODUCTLISTUNNO_LIST_TABLE: TableDetails = {
 
 export const ADR_PRODUCTLISTUNNO_TABLE: TableDetails = {
   tableName: "adr_productListUnNo",
-  columnNames: ["adr_details_id", "productListUnNo_id"],
+  columnNames: ["adr_details_id", "adr_productListUnNo_list_id"],
 };
 
 export const ADR_TC3DETAILS_TABLE: TableDetails = {
@@ -479,11 +482,11 @@ export const allTables = (): TableDetails[] => {
     CUSTOM_DEFECT_TABLE,
     TEST_RESULT_TABLE,
     ADR_ADDITIONAL_EXAMINER_NOTES_TABLE,
-    ADR_ADDITIONAL_NOTES_GUIDANCE_TABLE,
     ADR_ADDITIONAL_NOTES_NUMBER_TABLE,
     ADR_DANGEROUS_GOODS_LIST_TABLE,
     ADR_DETAILS_TABLE,
     ADR_MEMOS_APPLY_TABLE,
+    ADR_TANK_DOCUMENTS_TABLE,
     ADR_PERMITTED_DANGEROUS_GOODS_TABLE,
     ADR_PRODUCTLISTUNNO_LIST_TABLE,
     ADR_PRODUCTLISTUNNO_TABLE,

--- a/src/services/table-details.ts
+++ b/src/services/table-details.ts
@@ -364,6 +364,95 @@ export const TEST_RESULT_TABLE: TableDetails = {
   ],
 };
 
+export const ADR_ADDITIONAL_EXAMINER_NOTES_TABLE: TableDetails = {
+  tableName: "adr_additional_examiner_notes",
+  columnNames: ["adr_details_id", "note", "createdAtDate", "lastUpdatedBy"],
+};
+
+export const ADR_ADDITIONAL_NOTES_GUIDANCE_TABLE: TableDetails = {
+  tableName: "adr_additional_notes_guidance",
+  columnNames: ["guidanceNotes", "adr_details_id"],
+};
+
+export const ADR_ADDITIONAL_NOTES_NUMBER_TABLE: TableDetails = {
+  tableName: "adr_additional_notes_number",
+  columnNames: ["number", "adr_details_id"],
+};
+
+export const ADR_DANGEROUS_GOODS_LIST_TABLE: TableDetails = {
+  tableName: "adr_dangerous_goods_list",
+  columnNames: ["name"],
+};
+
+export const ADR_DETAILS_TABLE: TableDetails = {
+  tableName: "adr_details",
+  columnNames: [
+    "technical_record_id",
+    "type",
+    "approvalDate",
+    "listStatementApplicable",
+    "batteryListNumber",
+    "declarationsSeen",
+    "brakeDeclarationsSeen",
+    "brakeDeclarationIssuer",
+    "brakeEndurance",
+    "weight",
+    "compatibilityGroupJ",
+    "additionalExaminerNotes",
+    "applicantDetailsName",
+    "street",
+    "town",
+    "city",
+    "postcode",
+    "memosApply",
+    "adrTypeApprovalNo",
+    "adrCertificateNotes",
+    "tankManufacturer",
+    "yearOfManufacture",
+    "tankCode",
+    "specialProvisions",
+    "tankManufacturerSerialNo",
+    "tankTypeAppNo",
+    "tc2Type",
+    "tc2IntermediateApprovalNo",
+    "tc2IntermediateExpiryDate",
+    "substancesPermitted",
+    "statement",
+    "productListRefNo",
+    "productList",
+  ],
+};
+
+export const ADR_MEMOS_APPLY_TABLE: TableDetails = {
+  tableName: "adr_memos_apply",
+  columnNames: ["adr_details_id", "memo"],
+};
+
+export const ADR_PERMITTED_DANGEROUS_GOODS_TABLE: TableDetails = {
+  tableName: "adr_permitted_dangerous_goods",
+  columnNames: ["adr_details_id", "dangerous_goods_id"],
+};
+
+export const ADR_PRODUCTLISTUNNO_LIST_TABLE: TableDetails = {
+  tableName: "adr_productListUnNo_list",
+  columnNames: ["name"],
+};
+
+export const ADR_PRODUCTLISTUNNO_TABLE: TableDetails = {
+  tableName: "adr_productListUnNo",
+  columnNames: ["adr_details_id", "productListUnNo_id"],
+};
+
+export const ADR_TC3DETAILS_TABLE: TableDetails = {
+  tableName: "adr_tc3Details",
+  columnNames: [
+    "adr_details_id",
+    "tc3Type",
+    "tc3PeriodicNumber",
+    "tc3PeriodicExpiryDate",
+  ],
+};
+
 export const allTables = (): TableDetails[] => {
   return [
     VEHICLE_TABLE,
@@ -389,5 +478,15 @@ export const allTables = (): TableDetails[] => {
     TEST_DEFECT_TABLE,
     CUSTOM_DEFECT_TABLE,
     TEST_RESULT_TABLE,
+    ADR_ADDITIONAL_EXAMINER_NOTES_TABLE,
+    ADR_ADDITIONAL_NOTES_GUIDANCE_TABLE,
+    ADR_ADDITIONAL_NOTES_NUMBER_TABLE,
+    ADR_DANGEROUS_GOODS_LIST_TABLE,
+    ADR_DETAILS_TABLE,
+    ADR_MEMOS_APPLY_TABLE,
+    ADR_PERMITTED_DANGEROUS_GOODS_TABLE,
+    ADR_PRODUCTLISTUNNO_LIST_TABLE,
+    ADR_PRODUCTLISTUNNO_TABLE,
+    ADR_TC3DETAILS_TABLE,
   ];
 };

--- a/src/services/tech-record-document-conversion.ts
+++ b/src/services/tech-record-document-conversion.ts
@@ -18,11 +18,22 @@ import {
   VEHICLE_SUBCLASS_TABLE,
   VEHICLE_TABLE,
   AUTH_INTO_SERVICE_TABLE,
+  ADR_ADDITIONAL_EXAMINER_NOTES_TABLE,
+  ADR_ADDITIONAL_NOTES_NUMBER_TABLE,
+  ADR_DANGEROUS_GOODS_LIST_TABLE,
+  ADR_DETAILS_TABLE,
+  ADR_MEMOS_APPLY_TABLE,
+  ADR_PERMITTED_DANGEROUS_GOODS_TABLE,
+  ADR_PRODUCTLISTUNNO_LIST_TABLE,
+  ADR_PRODUCTLISTUNNO_TABLE,
+  ADR_TC3DETAILS_TABLE,
+  ADR_TANK_DOCUMENTS_TABLE,
 } from "./table-details";
 import {
   deleteBasedOnWhereIn,
   executeFullUpsert,
   executePartialUpsertIfNotExists,
+  executePartialUpsertIfNotExistsWithCondition,
 } from "./sql-execution";
 import { getConnectionPool } from "./connection-pool";
 import { Connection } from "mysql2/promise";
@@ -218,6 +229,91 @@ const upsertTechRecords = async (
         techRecordId,
         techRecord
       );
+
+      // upsert adr-details
+      if (techRecord.adrDetails) {
+        const adrResponse = await executeFullUpsert(
+          ADR_DETAILS_TABLE,
+          [
+            techRecordId,
+            techRecord.adrDetails.vehicleDetails?.type,
+            techRecord.adrDetails.vehicleDetails?.approvalDate,
+            techRecord.adrDetails.listStatementApplicable,
+            techRecord.adrDetails.batteryListNumber,
+            techRecord.adrDetails.declarationsSeen,
+            techRecord.adrDetails.brakeDeclarationsSeen,
+            techRecord.adrDetails.brakeDeclarationIssuer,
+            techRecord.adrDetails.brakeEndurance,
+            techRecord.adrDetails.weight,
+            techRecord.adrDetails.compatibilityGroupJ,
+            // techRecord.adrDetails.dangerousGoods,
+            techRecord.adrDetails.applicantDetails?.name,
+            techRecord.adrDetails.applicantDetails?.street,
+            techRecord.adrDetails.applicantDetails?.town,
+            techRecord.adrDetails.applicantDetails?.city,
+            techRecord.adrDetails.applicantDetails?.postcode,
+            techRecord.adrDetails.adrTypeApprovalNo,
+            techRecord.adrDetails.adrCertificateNotes,
+            techRecord.adrDetails.tank?.tankDetails?.tankManufacturer,
+            techRecord.adrDetails.tank?.tankDetails?.yearOfManufacture,
+            techRecord.adrDetails.tank?.tankDetails?.tankCode,
+            techRecord.adrDetails.tank?.tankDetails?.specialProvisions,
+            techRecord.adrDetails.tank?.tankDetails?.tankManufacturerSerialNo,
+            techRecord.adrDetails.tank?.tankDetails?.tankTypeAppNo,
+            techRecord.adrDetails.tank?.tankDetails?.tc2Details?.tc2Type,
+            techRecord.adrDetails.tank?.tankDetails?.tc2Details
+              ?.tc2IntermediateApprovalNo,
+            techRecord.adrDetails.tank?.tankDetails?.tc2Details
+              ?.tc2IntermediateExpiryDate,
+            techRecord.adrDetails.tank?.tankStatement?.substancesPermitted,
+            // techRecord.adrDetails.tank?.tankStatement?.select,
+            techRecord.adrDetails.tank?.tankStatement?.statement,
+            techRecord.adrDetails.tank?.tankStatement?.productListRefNo,
+            techRecord.adrDetails.tank?.tankStatement?.productList,
+            techRecord.adrDetails.m145Statement,
+            // techRecord.adrDetails.newCertificateRequested,
+          ],
+          techRecordConnection
+        );
+
+        const adrDetailsId = adrResponse.rows.insertId;
+
+        await upsertAdrMemosApply(
+          techRecordConnection,
+          adrDetailsId,
+          techRecord
+        );
+        await upsertAdrPermittedDangerousGoods(
+          techRecordConnection,
+          adrDetailsId,
+          techRecord
+        );
+        await upsertAdrProductListUnNo(
+          techRecordConnection,
+          adrDetailsId,
+          techRecord
+        );
+        await upsertAdrTc3Details(
+          techRecordConnection,
+          adrDetailsId,
+          techRecord
+        );
+        await upsertAdrAdditionalExaminerNotes(
+          techRecordConnection,
+          adrDetailsId,
+          techRecord
+        );
+        await upsertAdrAdditionalNotesNumber(
+          techRecordConnection,
+          adrDetailsId,
+          techRecord
+        );
+        // await upsertAdrTankDocuments(
+        //   techRecordConnection,
+        //   adrDetailsId,
+        //   techRecord
+        // );
+      }
 
       await techRecordConnection.commit();
     } catch (err) {
@@ -633,4 +729,242 @@ const upsertAuthIntoService = async (
   debugLog(
     `upsertTechRecords: Upserted authIntoService (tech-record-id: ${techRecordId}, ID: ${response.rows.insertId})`
   );
+};
+
+const upsertAdrMemosApply = async (
+  connection: Connection,
+  adrDetailsId: string,
+  techRecord: TechRecord
+): Promise<void> => {
+  if (techRecord.adrDetails?.memosApply) {
+    debugLog(
+      `upsertTechRecords: Upserting ADR memos_apply (adr-details-id: ${adrDetailsId})...`
+    );
+
+    for (const memo of techRecord.adrDetails?.memosApply) {
+      const response = await executeFullUpsert(
+        ADR_MEMOS_APPLY_TABLE,
+        [adrDetailsId, memo],
+        connection
+      );
+
+      debugLog(
+        `upsertTechRecords: Upserted ADR memos-apply (adr-details-id: ${adrDetailsId}, ID: ${response.rows.insertId})`
+      );
+    }
+  }
+  return;
+};
+
+const upsertAdrDangerousGoodsList = async (
+  connection: Connection,
+  dangerousGoodsName: string
+): Promise<number> => {
+  debugLog(`upsertTechRecords: Selecting/Upserting adr_dangerous_goods_list...`);
+
+  const response = await executePartialUpsertIfNotExistsWithCondition(
+    ADR_DANGEROUS_GOODS_LIST_TABLE,
+    {name: dangerousGoodsName},
+    connection
+  );
+
+  debugLog(
+    `upsertTechRecords: Selected adr_dangerous_goods_list (ID ${response.rows.insertId})`
+  );
+
+  return response.rows.insertId;
+};
+
+const upsertAdrPermittedDangerousGoods = async (
+  connection: Connection,
+  adrDetailsId: string,
+  techRecord: TechRecord
+): Promise<void> => {
+  if (techRecord.adrDetails?.permittedDangerousGoods) {
+    debugLog(
+      `upsertTechRecords: Upserting ADR permitted_dangerous_goods (adr-details-id: ${adrDetailsId})...`
+    );
+
+    for (const permittedDangerousGoods of techRecord.adrDetails
+      ?.permittedDangerousGoods) {
+      const permittedDangerousGoodsId = await upsertAdrDangerousGoodsList(
+        connection,
+        permittedDangerousGoods
+      );
+
+      const response = await executeFullUpsert(
+        ADR_PERMITTED_DANGEROUS_GOODS_TABLE,
+        [adrDetailsId, permittedDangerousGoodsId],
+        connection
+      );
+
+      debugLog(
+        `upsertTechRecords: Upserted ADR permitted_dangerous_goods (adr-details-id: ${adrDetailsId}, ID: ${response.rows.insertId})`
+      );
+    }
+  }
+  return;
+};
+
+const upsertAdrProductListUnNoList = async (
+  connection: Connection,
+  productListUnNo: string
+): Promise<number> => {
+  debugLog(`upsertTechRecords: Upserting adr_productListUnNo_list...`);
+
+  const response = await executePartialUpsertIfNotExistsWithCondition(
+    ADR_PRODUCTLISTUNNO_LIST_TABLE,
+    {name: productListUnNo},
+    connection
+  );
+
+  debugLog(
+    `upsertTechRecords: Upserted adr_productListUnNo_list (ID ${response.rows.insertId})`
+  );
+
+  return response.rows.insertId;
+};
+
+const upsertAdrProductListUnNo = async (
+  connection: Connection,
+  adrDetailsId: string,
+  techRecord: TechRecord
+): Promise<void> => {
+  if (techRecord.adrDetails?.tank?.tankStatement?.productListUnNo) {
+    debugLog(
+      `upsertTechRecords: Upserting ADR tankStatement productListUnNo (adr-details-id: ${adrDetailsId})...`
+    );
+
+    for (const productListUnNo of techRecord.adrDetails?.tank?.tankStatement
+      ?.productListUnNo) {
+      const productListUnNoId = await upsertAdrProductListUnNoList(
+        connection,
+        productListUnNo
+      );
+
+      const response = await executeFullUpsert(
+        ADR_PRODUCTLISTUNNO_TABLE,
+        [adrDetailsId, productListUnNoId],
+        connection
+      );
+
+      debugLog(
+        `upsertTechRecords: Upserted ADR tankStatement productListUnNo (adr-details-id: ${adrDetailsId}, ID: ${response.rows.insertId})`
+      );
+    }
+  }
+  return;
+};
+
+const upsertAdrTc3Details = async (
+  connection: Connection,
+  adrDetailsId: string,
+  techRecord: TechRecord
+): Promise<void> => {
+  if (techRecord.adrDetails?.tank?.tankDetails?.tc3Details) {
+    debugLog(
+      `upsertTechRecords: Upserting ADR tc3Details (adr-details-id: ${adrDetailsId})...`
+    );
+
+    for (const tc3Details of techRecord.adrDetails?.tank?.tankDetails
+      ?.tc3Details) {
+      const response = await executeFullUpsert(
+        ADR_TC3DETAILS_TABLE,
+        [
+          adrDetailsId,
+          tc3Details.tc3Type,
+          tc3Details.tc3PeriodicNumber,
+          tc3Details.tc3PeriodicExpiryDate,
+        ],
+        connection
+      );
+
+      debugLog(
+        `upsertTechRecords: Upserted ADR tc3Details (adr-details-id: ${adrDetailsId}, ID: ${response.rows.insertId})`
+      );
+    }
+  }
+  return;
+};
+
+const upsertAdrAdditionalExaminerNotes = async (
+  connection: Connection,
+  adrDetailsId: string,
+  techRecord: TechRecord
+): Promise<void> => {
+  if (techRecord.adrDetails?.additionalExaminerNotes) {
+    debugLog(
+      `upsertTechRecords: Upserting ADR additionalExaminerNotes (adr-details-id: ${adrDetailsId})...`
+    );
+
+    for (const additionalExaminerNotes of techRecord.adrDetails
+      ?.additionalExaminerNotes) {
+      const response = await executeFullUpsert(
+        ADR_ADDITIONAL_EXAMINER_NOTES_TABLE,
+        [
+          adrDetailsId,
+          additionalExaminerNotes.note,
+          additionalExaminerNotes.createdAtDate,
+          additionalExaminerNotes.lastUpdatedBy,
+        ],
+        connection
+      );
+
+      debugLog(
+        `upsertTechRecords: Upserted ADR additionalExaminerNotes (adr-details-id: ${adrDetailsId}, ID: ${response.rows.insertId})`
+      );
+    }
+  }
+  return;
+};
+
+const upsertAdrAdditionalNotesNumber = async (
+  connection: Connection,
+  adrDetailsId: string,
+  techRecord: TechRecord
+): Promise<void> => {
+  if (techRecord.adrDetails?.additionalNotes?.number) {
+    debugLog(
+      `upsertTechRecords: Upserting ADR additional_notes_number (adr-details-id: ${adrDetailsId})...`
+    );
+
+    for (const additionalNotesNumber of techRecord.adrDetails?.additionalNotes
+      ?.number) {
+      const response = await executeFullUpsert(
+        ADR_ADDITIONAL_NOTES_NUMBER_TABLE,
+        [additionalNotesNumber, adrDetailsId],
+        connection
+      );
+
+      debugLog(
+        `upsertTechRecords: Upserted ADR additional_notes_number (adr-details-id: ${adrDetailsId}, ID: ${response.rows.insertId})`
+      );
+    }
+  }
+  return;
+};
+
+const upsertAdrTankDocuments = async (
+  connection: Connection,
+  adrDetailsId: string,
+  techRecord: TechRecord
+): Promise<void> => {
+  if (techRecord.adrDetails?.documents) {
+    debugLog(
+      `upsertTechRecords: Upserting ADR tank documents (adr-details-id: ${adrDetailsId})...`
+    );
+
+    for (const documents of techRecord.adrDetails?.documents) {
+      const response = await executeFullUpsert(
+        ADR_TANK_DOCUMENTS_TABLE,
+        [adrDetailsId, documents],
+        connection
+      );
+
+      debugLog(
+        `upsertTechRecords: Upserted ADR tank documents (adr-details-id: ${adrDetailsId}, ID: ${response.rows.insertId})`
+      );
+    }
+  }
+  return;
 };

--- a/tests/integration/tech-record-document-conversion.intTest.ts
+++ b/tests/integration/tech-record-document-conversion.intTest.ts
@@ -4,7 +4,7 @@ import {
   executeSql,
 } from "../../src/services/connection-pool";
 import { exampleContext, useLocalDb } from "../utils";
-import techRecordDocumentJson from "../resources/dynamodb-image-technical-record.json";
+import techRecordDocumentJsonWithADR from "../resources/dynamodb-image-technical-record-with-adr.json";
 import { getContainerizedDatabase } from "./cvsbnop-container";
 import { processStreamEvent } from "../../src/functions/process-stream-event";
 import { getConnectionPoolOptions } from "../../src/services/connection-pool-options";
@@ -12,7 +12,7 @@ import { getConnectionPoolOptions } from "../../src/services/connection-pool-opt
 useLocalDb();
 
 export const techRecordDocumentConversion = () =>
-  describe("convertTechRecordDocument() integration tests", () => {
+  describe("convertTechRecordDocument() with ADR integration tests", () => {
     let container: StartedTestContainer;
 
     beforeAll(async () => {
@@ -49,7 +49,7 @@ export const techRecordDocumentConversion = () =>
                 "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
               eventName: "INSERT",
               dynamodb: {
-                NewImage: techRecordDocumentJson,
+                NewImage: techRecordDocumentJsonWithADR,
               },
             }),
           },
@@ -590,13 +590,259 @@ export const techRecordDocumentConversion = () =>
       expect(
         (authIntoServiceResultSet.rows[0].dateRejected as Date).toUTCString()
       ).toEqual("Tue, 05 May 2020 00:00:00 GMT");
+
+      // adr_details
+      const adrDetailsResultSet = await executeSql(
+        `SELECT \`id\`,
+                \`technical_record_id\`,
+                \`type\`,
+                \`approvalDate\`,
+                \`listStatementApplicable\`,
+                \`batteryListNumber\`,
+                \`declarationsSeen\`,
+                \`brakeDeclarationsSeen\`,
+                \`brakeDeclarationIssuer\`,
+                \`brakeEndurance\`,
+                \`weight\`,
+                \`compatibilityGroupJ\`,
+                \`applicantDetailsName\`,
+                \`street\`,
+                \`town\`,
+                \`city\`,
+                \`postcode\`,
+                \`adrTypeApprovalNo\`,
+                \`adrCertificateNotes\`,
+                \`tankManufacturer\`,
+                \`yearOfManufacture\`,
+                \`tankCode\`,
+                \`specialProvisions\`,
+                \`tankManufacturerSerialNo\`,
+                \`tankTypeAppNo\`,
+                \`tc2Type\`,
+                \`tc2IntermediateApprovalNo\`,
+                \`tc2IntermediateExpiryDate\`,
+                \`substancesPermitted\`,
+                \`statement\`,
+                \`productListRefNo\`,
+                \`productList\`,
+                \`m145Statement\`
+             FROM \`adr_details\`
+             WHERE \`adr_details\`.\`technical_record_id\` = ${technicalRecordId}`
+      );
+      expect(adrDetailsResultSet.rows.length).toEqual(1);
+      expect(adrDetailsResultSet.rows[0].technical_record_id).toEqual(
+        technicalRecordId
+      );
+      expect(adrDetailsResultSet.rows[0].type).toEqual("Artic tractor");
+      expect(
+        (adrDetailsResultSet.rows[0].approvalDate as Date).toUTCString()
+      ).toEqual("Mon, 12 Jun 2023 00:00:00 GMT");
+      expect(adrDetailsResultSet.rows[0].listStatementApplicable).toEqual(1);
+      expect(adrDetailsResultSet.rows[0].batteryListNumber).toEqual("BATTERY1");
+      expect(adrDetailsResultSet.rows[0].declarationsSeen).toEqual(0);
+      expect(adrDetailsResultSet.rows[0].brakeDeclarationsSeen).toEqual(1);
+      expect(adrDetailsResultSet.rows[0].brakeDeclarationIssuer).toEqual(
+        "brakeDeclarationIssuer_1"
+      );
+      expect(adrDetailsResultSet.rows[0].brakeEndurance).toEqual(0);
+      expect(adrDetailsResultSet.rows[0].weight).toEqual(6789);
+      expect(adrDetailsResultSet.rows[0].compatibilityGroupJ).toEqual("I");
+      expect(adrDetailsResultSet.rows[0].applicantDetailsName).toEqual(
+        "applicantDetails_Name"
+      );
+      expect(adrDetailsResultSet.rows[0].street).toEqual(
+        "applicantDetailsSTREET"
+      );
+      expect(adrDetailsResultSet.rows[0].town).toEqual("applicantDetailsTOWN");
+      expect(adrDetailsResultSet.rows[0].city).toEqual("applicantDetailsCITY");
+      expect(adrDetailsResultSet.rows[0].postcode).toEqual("POST-CODE");
+      expect(adrDetailsResultSet.rows[0].adrTypeApprovalNo).toEqual(
+        "adrTypeApprovalNo_1"
+      );
+      expect(adrDetailsResultSet.rows[0].adrCertificateNotes).toEqual(
+        "adrCertificateNotes_1"
+      );
+      expect(adrDetailsResultSet.rows[0].tankManufacturer).toEqual(
+        "tankManufacturer_1"
+      );
+      expect(adrDetailsResultSet.rows[0].yearOfManufacture).toEqual(2012);
+      expect(adrDetailsResultSet.rows[0].tankCode).toEqual("tankCode_1");
+      expect(adrDetailsResultSet.rows[0].specialProvisions).toEqual(
+        "specialProvisions_1"
+      );
+      expect(adrDetailsResultSet.rows[0].tankManufacturerSerialNo).toEqual(
+        "1234"
+      );
+      expect(adrDetailsResultSet.rows[0].tankTypeAppNo).toEqual("9876");
+      expect(adrDetailsResultSet.rows[0].tc2Type).toEqual("initial");
+      expect(adrDetailsResultSet.rows[0].tc2IntermediateApprovalNo).toEqual(
+        "12345"
+      );
+      expect(
+        (adrDetailsResultSet.rows[0]
+          .tc2IntermediateExpiryDate as Date).toUTCString()
+      ).toEqual("Sat, 01 Jun 2024 00:00:00 GMT");
+      expect(adrDetailsResultSet.rows[0].substancesPermitted).toEqual(
+        "Substances permitted under the tank code and any special provisions specified in 9 may be carried"
+      );
+      expect(adrDetailsResultSet.rows[0].statement).toEqual("statement_1");
+      expect(adrDetailsResultSet.rows[0].productListRefNo).toEqual("123456");
+      expect(adrDetailsResultSet.rows[0].productList).toEqual("productList_1");
+      expect(adrDetailsResultSet.rows[0].m145Statement).toEqual(1);
+
+      const adrDetailsId = adrDetailsResultSet.rows[0].id;
+
+      // adr_memos_apply
+      const adrMemosApplyResultSet = await executeSql(
+        `SELECT \`adr_details_id\`,
+                \`memo\`
+             FROM \`adr_memos_apply\`
+             WHERE \`adr_memos_apply\`.\`adr_details_id\` = ${adrDetailsId}`
+      );
+      expect(adrMemosApplyResultSet.rows.length).toEqual(1);
+      expect(adrMemosApplyResultSet.rows[0].adr_details_id).toEqual(
+        adrDetailsId
+      );
+      expect(adrMemosApplyResultSet.rows[0].memo).toEqual(
+        "07/09 3mth leak ext"
+      );
+
+      // adr_dangerous_goods_list
+      const adrDangerousGoodsListResultSet = await executeSql(
+        `SELECT \`id\`,
+                \`name\`
+             FROM \`adr_dangerous_goods_list\`
+             `
+      );
+      expect(adrDangerousGoodsListResultSet.rows.length).toEqual(3);
+
+      expect(adrDangerousGoodsListResultSet.rows[0].name).toEqual(
+        "FP <61 (FL)"
+      );
+      expect(adrDangerousGoodsListResultSet.rows[1].name).toEqual(
+        "Carbon Disulphide"
+      );
+      expect(adrDangerousGoodsListResultSet.rows[2].name).toEqual("Hydrogen");
+
+      // adr_permitted_dangerous_goods
+      const adrPermittedDangerousGoodsResultSet = await executeSql(
+        `SELECT \`adr_details_id\`,
+                \`adr_dangerous_goods_list_id\`
+             FROM \`adr_permitted_dangerous_goods\`
+             WHERE \`adr_permitted_dangerous_goods\`.\`adr_details_id\` = ${adrDetailsId}`
+      );
+      expect(adrPermittedDangerousGoodsResultSet.rows.length).toEqual(3);
+      expect(
+        adrPermittedDangerousGoodsResultSet.rows[0].adr_details_id
+      ).toEqual(adrDetailsId);
+      expect(
+        adrPermittedDangerousGoodsResultSet.rows[0].adr_dangerous_goods_list_id
+      ).toEqual(1);
+      expect(
+        adrPermittedDangerousGoodsResultSet.rows[1].adr_dangerous_goods_list_id
+      ).toEqual(2);
+      expect(
+        adrPermittedDangerousGoodsResultSet.rows[2].adr_dangerous_goods_list_id
+      ).toEqual(3);
+
+      // adr_productListUnNo_list
+      const adrProductListUnNoListResultSet = await executeSql(
+        `SELECT \`id\`,
+                \`name\`
+             FROM \`adr_productListUnNo_list\`
+             `
+      );
+      expect(adrProductListUnNoListResultSet.rows.length).toEqual(3);
+
+      expect(adrProductListUnNoListResultSet.rows[0].name).toEqual("123123");
+      expect(adrProductListUnNoListResultSet.rows[1].name).toEqual("987987");
+      expect(adrProductListUnNoListResultSet.rows[2].name).toEqual("135790");
+
+      // adr_productListUnNo
+      const adrProductListUnNoResultSet = await executeSql(
+        `SELECT \`adr_details_id\`,
+                \`adr_productListUnNo_list_id\`
+             FROM \`adr_productListUnNo\`
+             WHERE \`adr_productListUnNo\`.\`adr_details_id\` = ${adrDetailsId}`
+      );
+      expect(adrProductListUnNoResultSet.rows.length).toEqual(3);
+      expect(adrProductListUnNoResultSet.rows[0].adr_details_id).toEqual(
+        adrDetailsId
+      );
+      expect(
+        adrProductListUnNoResultSet.rows[0].adr_productListUnNo_list_id
+      ).toEqual(1);
+      expect(
+        adrProductListUnNoResultSet.rows[1].adr_productListUnNo_list_id
+      ).toEqual(2);
+      expect(
+        adrProductListUnNoResultSet.rows[2].adr_productListUnNo_list_id
+      ).toEqual(3);
+
+      // adr_tc3Details
+      const adrTc3DetailsResultSet = await executeSql(
+        `SELECT \`adr_details_id\`,
+                \`tc3Type\`,
+                \`tc3PeriodicNumber\`,
+                \`tc3PeriodicExpiryDate\`
+             FROM \`adr_tc3Details\`
+             WHERE \`adr_tc3Details\`.\`adr_details_id\` = ${adrDetailsId}`
+      );
+      expect(adrTc3DetailsResultSet.rows.length).toEqual(1);
+      expect(adrTc3DetailsResultSet.rows[0].adr_details_id).toEqual(
+        adrDetailsId
+      );
+      expect(adrTc3DetailsResultSet.rows[0].tc3Type).toEqual("intermediate");
+      expect(adrTc3DetailsResultSet.rows[0].tc3PeriodicNumber).toEqual("98765");
+      expect(
+        (adrTc3DetailsResultSet.rows[0]
+          .tc3PeriodicExpiryDate as Date).toUTCString()
+      ).toEqual("Sat, 01 Jun 2024 00:00:00 GMT");
+
+      // adr_additional_examiner_notes
+      const adrAdditionalExaminerNotesResultSet = await executeSql(
+        `SELECT \`adr_details_id\`,
+                \`note\`,
+                \`createdAtDate\`,
+                \`lastUpdatedBy\`
+             FROM \`adr_additional_examiner_notes\`
+             WHERE \`adr_additional_examiner_notes\`.\`adr_details_id\` = ${adrDetailsId}`
+      );
+      expect(adrAdditionalExaminerNotesResultSet.rows.length).toEqual(1);
+      expect(
+        adrAdditionalExaminerNotesResultSet.rows[0].adr_details_id
+      ).toEqual(adrDetailsId);
+      expect(adrAdditionalExaminerNotesResultSet.rows[0].note).toEqual(
+        "additionalExaminerNotes_note_1"
+      );
+      expect(
+        (adrAdditionalExaminerNotesResultSet.rows[0]
+          .createdAtDate as Date).toUTCString()
+      ).toEqual("Tue, 30 May 2023 00:00:00 GMT");
+      expect(adrAdditionalExaminerNotesResultSet.rows[0].lastUpdatedBy).toEqual(
+        "additionalExaminerNotes_lastUpdatedBy_1"
+      );
+
+      // adr_additional_notes_number
+      const adrAdditionalNotesNumberResultSet = await executeSql(
+        `SELECT \`adr_details_id\`,
+                \`number\`
+             FROM \`adr_additional_notes_number\`
+             WHERE \`adr_additional_notes_number\`.\`adr_details_id\` = ${adrDetailsId}`
+      );
+      expect(adrAdditionalNotesNumberResultSet.rows.length).toEqual(2);
+      expect(adrAdditionalNotesNumberResultSet.rows[0].adr_details_id).toEqual(
+        adrDetailsId
+      );
+      expect(adrAdditionalNotesNumberResultSet.rows[0].number).toEqual("1");
+      expect(adrAdditionalNotesNumberResultSet.rows[1].number).toEqual("T1B");
     });
 
     describe("when adding a new vehicle and changing VRM to a new value, VRM should change on existing vehicle.", () => {
       it("A new vehicle is present", async () => {
         // arrange - create a record so we can later query for it and assert for is existence
         const techRecordDocumentJsonNew = JSON.parse(
-          JSON.stringify(techRecordDocumentJson)
+          JSON.stringify(techRecordDocumentJsonWithADR)
         );
         techRecordDocumentJsonNew.systemNumber = { S: "SYSTEM-NUMBER-2" };
         techRecordDocumentJsonNew.vin = { S: "VIN2" };
@@ -642,7 +888,7 @@ export const techRecordDocumentConversion = () =>
       it("VRM has changed", async () => {
         // arrange - create a record with existing pair of (SystemNumber, VIN) and new VRM so we can later query for it and assert its value
         const techRecordDocumentJsonNew = JSON.parse(
-          JSON.stringify(techRecordDocumentJson)
+          JSON.stringify(techRecordDocumentJsonWithADR)
         );
         techRecordDocumentJsonNew.systemNumber = { S: "SYSTEM-NUMBER-2" };
         techRecordDocumentJsonNew.vin = { S: "VIN2" };

--- a/tests/resources/Dockerfile
+++ b/tests/resources/Dockerfile
@@ -1,5 +1,5 @@
 # Match Aurora MySQL version as closely as possible
-FROM mysql:5.7.12
+FROM mysql:8.2.0
 
 ENV MYSQL_DATABASE=CVSBNOP \
 MYSQL_ROOT_PASSWORD=12345

--- a/tests/resources/Dockerfile
+++ b/tests/resources/Dockerfile
@@ -1,5 +1,5 @@
 # Match Aurora MySQL version as closely as possible
-FROM mysql:8.2.0
+FROM mysql:8.0.32
 
 ENV MYSQL_DATABASE=CVSBNOP \
 MYSQL_ROOT_PASSWORD=12345

--- a/tests/resources/dynamodb-image-technical-record-with-adr.json
+++ b/tests/resources/dynamodb-image-technical-record-with-adr.json
@@ -25,227 +25,227 @@
     "L": [
       {
         "M": {
-            "adrDetails": {
+          "adrDetails": {
+            "M": {
+              "additionalExaminerNotes": {
+                "L": [
+                  {
+                    "M": {
+                      "note": {
+                        "S": "additionalExaminerNotes_note_1"
+                      },
+                      "createdAtDate": {
+                        "S": "2023-05-30"
+                      },
+                      "lastUpdatedBy": {
+                        "S": "additionalExaminerNotes_lastUpdatedBy_1"
+                      }
+                    }
+                  }
+                ]
+              },
+              "additionalNotes": {
                 "M": {
-                  "additionalExaminerNotes": {
+                  "number": {
                     "L": [
-                        {
-                            "M": {
-                                "note": {
-                                    "S": "additionalExaminerNotes_note_1"
-                                },
-                                "createdAtDate": {
-                                    "S": "2023-05-30"
-                                },
-                                "lastUpdatedBy": {
-                                    "S": "additionalExaminerNotes_lastUpdatedBy_1"
-                                }
-                            }
-                        }
+                      {"S": "1"},
+                      {"S": "T1B"}
                     ]
+                  }
+                }
+              },
+              "adrCertificateNotes": {
+                "S": "adrCertificateNotes_1"
+              },
+              "adrTypeApprovalNo": {
+                "S": "adrTypeApprovalNo_1"
+              },
+              "applicantDetails": {
+                "M": {
+                  "name": {
+                    "S": "applicantDetails_Name"
                   },
-                  "additionalNotes": {
-                    "M": {
-                        "number": {
-                            "L": [
-                                {"S": "1"},
-                                {"S": "T1B"}
-                            ]
-                        }
-                    }
+                  "street": {
+                    "S": "applicantDetailsSTREET"
                   },
-                  "adrCertificateNotes": {
-                    "S": "adrCertificateNotes_1"
+                  "town": {
+                    "S": "applicantDetailsTOWN"
                   },
-                  "adrTypeApprovalNo": {
-                    "S": "adrTypeApprovalNo_1"
+                  "city": {
+                    "S": "applicantDetailsCITY"
                   },
-                  "applicantDetails": {
-                    "M": {
-                      "name": {
-                            "S": "adrDetails_applicantDetails_name_1"
-                          },
-                      "street": {
-                            "S": "adrDetails_applicantDetails_street_1"
-                          },
-                      "town": {
-                            "S": "adrDetails_applicantDetails_town_1"
-                          },
-                      "city": {
-                            "S": "adrDetails_applicantDetails_city_1"
-                          },
-                      "postcode": {
-                            "S": "adrDetails_applicantDetails_postcode_1"
-                          }
-                    }
+                  "postcode": {
+                    "S": "POST-CODE"
+                  }
+                }
+              },
+              "batteryListNumber": {
+                "S": "BATTERY1"
+              },
+              "brakeDeclarationIssuer": {
+                "S": "brakeDeclarationIssuer_1"
+              },
+              "brakeDeclarationsSeen": {
+                "BOOL": true
+              },
+              "brakeEndurance": {
+                "BOOL": false
+              },
+              "compatibilityGroupJ": {
+                "S": "I"
+              },
+              "dangerousGoods": {
+                "BOOL": false
+              },
+              "declarationsSeen": {
+                "BOOL": false
+              },
+              "documents": {
+                "L": [
+                  {
+                    "S": "documents_1"
                   },
-                  "batteryListNumber": {
-                    "S": "batteryListNumber_1"
-                  },
-                  "brakeDeclarationIssuer": {
-                    "S": "brakeDeclarationIssuer_1"
-                  },
-                  "brakeDeclarationsSeen": {
-                    "BOOL": true
-                  },
-                  "brakeEndurance": {
-                    "BOOL": false
-                  },
-                  "compatibilityGroupJ": {
-                    "S": "I"
-                  },
-                  "dangerousGoods": {
-                    "BOOL": false
-                  },
-                  "declarationsSeen": {
-                    "BOOL": false
-                  },
-                  "documents": {
-                    "L": [
-                      {
-                        "S": "documents_1"
-                      },
-                      {
-                        "S": "documents_2"
-                      }, 
-                      {
-                        "S": "documents_3"
-                      }
-                    ]
-                  },
-                  "listStatementApplicable": {
-                    "BOOL": true
-                  },
-                  "m145Statement": {
-                    "BOOL": true
-                  },
-                  "newCertificateRequested": {
-                    "BOOL": false
-                  },
+                  {
+                    "S": "documents_2"
+                  }, 
+                  {
+                    "S": "documents_3"
+                  }
+                ]
+              },
+              "listStatementApplicable": {
+                "BOOL": true
+              },
+              "m145Statement": {
+                "BOOL": true
+              },
+              "newCertificateRequested": {
+                "BOOL": false
+              },
 
-                  "memosApply": {
-                    "L": [
-                      {
-                        "S": "07/09 3mth leak ext"
-                      }
-                    ]
+              "memosApply": {
+                "L": [
+                  {
+                    "S": "07/09 3mth leak ext"
+                  }
+                ]
+              },
+              "permittedDangerousGoods": {
+                "L": [
+                  {
+                    "S": "FP <61 (FL)"
                   },
-                  "permittedDangerousGoods": {
-                    "L": [
-                      {
-                        "S": "FP <61 (FL)"
-                      },
-                      {
-                        "S": "Carbon Disulphide"
-                      }, 
-                      {
-                        "S": "Hydrogen"
-                      }
-                    ]
-                  },
-                  "tank": {
+                  {
+                    "S": "Carbon Disulphide"
+                  }, 
+                  {
+                    "S": "Hydrogen"
+                  }
+                ]
+              },
+              "tank": {
+                "M": {
+                  "tankDetails": {
                     "M": {
-                      "tankDetails": {
+                      "tankManufacturer": {
+                        "S": "tankManufacturer_1"
+                      },
+                      "yearOfManufacture": {
+                        "N": "2012"
+                      },
+                      "tankCode": {
+                        "S": "tankCode_1"
+                      },
+                      "specialProvisions": {
+                        "S": "specialProvisions_1"
+                      },
+                      "tankManufacturerSerialNo": {
+                        "S": "1234"
+                      },
+                      "tankTypeAppNo": {
+                        "S": "9876"
+                      },
+                      "tc2Details": {
                         "M": {
-                          "tankManufacturer": {
-                            "S": "tankManufacturer_1"
+                          "tc2Type": {
+                            "S": "initial"
                           },
-                          "yearOfManufacture": {
-                            "N": "1234"
+                          "tc2IntermediateApprovalNo": {
+                            "S": "12345"
                           },
-                          "tankCode": {
-                            "S": "tankCode_1"
-                          },
-                          "specialProvisions": {
-                            "S": "specialProvisions_1"
-                          },
-                          "tankManufacturerSerialNo": {
-                            "S": "1234"
-                          },
-                          "tankTypeAppNo": {
-                            "S": "9876"
-                          },
-                          "tc2Details": {
+                          "tc2IntermediateExpiryDate": {
+                            "S": "2024-06-01"
+                          }
+                        }
+                      },
+                      "tc3Details": {
+                        "L": [
+                          {
                             "M": {
-                              "tc2Type": {
-                                "S": "initial"
+                              "tc3Type": {
+                                "S": "intermediate"
                               },
-                              "tc2IntermediateApprovalNo": {
-                                "S": "12345"
+                              "tc3PeriodicNumber": {
+                                "S": "98765"
                               },
-                              "tc2IntermediateExpiryDate": {
+                              "tc3PeriodicExpiryDate": {
                                 "S": "2024-06-01"
                               }
                             }
-                          },
-                          "tc3Details": {
-                            "L": [
-                              {
-                                "M": {
-                                  "tc3Type": {
-                                    "S": "intermediate"
-                                  },
-                                  "tc3PeriodicNumber": {
-                                    "S": "98765"
-                                  },
-                                  "tc3PeriodicExpiryDate": {
-                                    "S": "2024-06-01"
-                                  }
-                                }
-                              }
-                            ]
                           }
-                        }
-                      },
-                      "tankStatement": {
-                        "M": {
-                          "select":{
-                            "S": "Product list"
-                          },
-                          "substancesPermitted": {
-                            "S": "Substances permitted under the tank code and any special provisions specified in 9 may be carried"
-                          },
-                          "statement": {
-                            "S": "statement_1"
-                          },
-                          "productListRefNo": {
-                            "S": "123456"
-                          },
-                          "productListUnNo": {
-                            "L": [
-                              {
-                                "S": "123123"
-                              },
-                              {
-                                "S": "987987"
-                              },
-                              {
-                                "S": "135790"
-                              }
-                            ]
-                          },
-                          "productList": {
-                            "S": "productList_1"
-                          }
-                        }
-                      } 
-                    }
-                  },
-                  "vehicleDetails": {
-                    "M": {
-                      "type": {
-                        "S": "Artic tractor"
-                      },
-                      "approvalDate": {
-                        "S": "2023-06-12"
+                        ]
                       }
                     }
                   },
-                  "weight": {
-                    "N": "6789"
+                  "tankStatement": {
+                    "M": {
+                      "select":{
+                        "S": "Product list"
+                      },
+                      "substancesPermitted": {
+                        "S": "Substances permitted under the tank code and any special provisions specified in 9 may be carried"
+                      },
+                      "statement": {
+                        "S": "statement_1"
+                      },
+                      "productListRefNo": {
+                        "S": "123456"
+                      },
+                      "productListUnNo": {
+                        "L": [
+                          {
+                            "S": "123123"
+                          },
+                          {
+                            "S": "987987"
+                          },
+                          {
+                            "S": "135790"
+                          }
+                        ]
+                      },
+                      "productList": {
+                        "S": "productList_1"
+                      }
+                    }
+                  } 
+                }
+              },
+              "vehicleDetails": {
+                "M": {
+                  "type": {
+                    "S": "Artic tractor"
+                  },
+                  "approvalDate": {
+                    "S": "2023-06-12"
                   }
                 }
-              },  
+              },
+              "weight": {
+                "N": "6789"
+              }
+            }
+          },  
           "recordCompleteness": {
             "S": "88888888"
           },

--- a/tests/resources/dynamodb-image-technical-record-with-adr.json
+++ b/tests/resources/dynamodb-image-technical-record-with-adr.json
@@ -116,9 +116,13 @@
                   "listStatementApplicable": {
                     "BOOL": true
                   },
-                  "m145": {
+                  "m145Statement": {
                     "BOOL": true
                   },
+                  "newCertificateRequested": {
+                    "BOOL": false
+                  },
+
                   "memosApply": {
                     "L": [
                       {

--- a/tests/resources/dynamodb-image-technical-record-with-adr.json
+++ b/tests/resources/dynamodb-image-technical-record-with-adr.json
@@ -1,0 +1,847 @@
+{
+  "systemNumber": {
+    "S": "SYSTEM-NUMBER-1"
+  },
+  "partialVin": {
+    "S": "PARTIAL-VIN"
+  },
+  "primaryVrm": {
+    "S": "VRM-1"
+  },
+  "secondaryVrms": {
+    "L": [
+      {
+        "S": "SECONDARY-VRM"
+      }
+    ]
+  },
+  "vin": {
+    "S": "VIN-1"
+  },
+  "trailerId": {
+    "S": "TRL-1"
+  },
+  "techRecord": {
+    "L": [
+      {
+        "M": {
+            "adrDetails": {
+                "M": {
+                  "additionalExaminerNotes": {
+                    "L": [
+                        {
+                            "M": {
+                                "note": {
+                                    "S": "additionalExaminerNotes_note_1"
+                                },
+                                "createdAtDate": {
+                                    "S": "2023-05-30"
+                                },
+                                "lastUpdatedBy": {
+                                    "S": "additionalExaminerNotes_lastUpdatedBy_1"
+                                }
+                            }
+                        }
+                    ]
+                  },
+                  "additionalNotes": {
+                    "M": {
+                        "number": {
+                            "L": [
+                                {"S": "1"},
+                                {"S": "T1B"}
+                            ]
+                        }
+                    }
+                  },
+                  "adrCertificateNotes": {
+                    "S": "adrCertificateNotes_1"
+                  },
+                  "adrTypeApprovalNo": {
+                    "S": "adrTypeApprovalNo_1"
+                  },
+                  "applicantDetails": {
+                    "M": {
+                      "name": {
+                            "S": "adrDetails_applicantDetails_name_1"
+                          },
+                      "street": {
+                            "S": "adrDetails_applicantDetails_street_1"
+                          },
+                      "town": {
+                            "S": "adrDetails_applicantDetails_town_1"
+                          },
+                      "city": {
+                            "S": "adrDetails_applicantDetails_city_1"
+                          },
+                      "postcode": {
+                            "S": "adrDetails_applicantDetails_postcode_1"
+                          }
+                    }
+                  },
+                  "batteryListNumber": {
+                    "S": "batteryListNumber_1"
+                  },
+                  "brakeDeclarationIssuer": {
+                    "S": "brakeDeclarationIssuer_1"
+                  },
+                  "brakeDeclarationsSeen": {
+                    "BOOL": true
+                  },
+                  "brakeEndurance": {
+                    "BOOL": false
+                  },
+                  "compatibilityGroupJ": {
+                    "S": "I"
+                  },
+                  "dangerousGoods": {
+                    "BOOL": false
+                  },
+                  "declarationsSeen": {
+                    "BOOL": false
+                  },
+                  "documents": {
+                    "L": [
+                      {
+                        "S": "documents_1"
+                      },
+                      {
+                        "S": "documents_2"
+                      }, 
+                      {
+                        "S": "documents_3"
+                      }
+                    ]
+                  },
+                  "listStatementApplicable": {
+                    "BOOL": true
+                  },
+                  "m145": {
+                    "BOOL": true
+                  },
+                  "memosApply": {
+                    "L": [
+                      {
+                        "S": "07/09 3mth leak ext"
+                      }
+                    ]
+                  },
+                  "permittedDangerousGoods": {
+                    "L": [
+                      {
+                        "S": "FP <61 (FL)"
+                      },
+                      {
+                        "S": "Carbon Disulphide"
+                      }, 
+                      {
+                        "S": "Hydrogen"
+                      }
+                    ]
+                  },
+                  "tank": {
+                    "M": {
+                      "tankDetails": {
+                        "M": {
+                          "tankManufacturer": {
+                            "S": "tankManufacturer_1"
+                          },
+                          "yearOfManufacture": {
+                            "N": "1234"
+                          },
+                          "tankCode": {
+                            "S": "tankCode_1"
+                          },
+                          "specialProvisions": {
+                            "S": "specialProvisions_1"
+                          },
+                          "tankManufacturerSerialNo": {
+                            "S": "1234"
+                          },
+                          "tankTypeAppNo": {
+                            "S": "9876"
+                          },
+                          "tc2Details": {
+                            "M": {
+                              "tc2Type": {
+                                "S": "initial"
+                              },
+                              "tc2IntermediateApprovalNo": {
+                                "S": "12345"
+                              },
+                              "tc2IntermediateExpiryDate": {
+                                "S": "2024-06-01"
+                              }
+                            }
+                          },
+                          "tc3Details": {
+                            "L": [
+                              {
+                                "M": {
+                                  "tc3Type": {
+                                    "S": "intermediate"
+                                  },
+                                  "tc3PeriodicNumber": {
+                                    "S": "98765"
+                                  },
+                                  "tc3PeriodicExpiryDate": {
+                                    "S": "2024-06-01"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "tankStatement": {
+                        "M": {
+                          "select":{
+                            "S": "Product list"
+                          },
+                          "substancesPermitted": {
+                            "S": "Substances permitted under the tank code and any special provisions specified in 9 may be carried"
+                          },
+                          "statement": {
+                            "S": "statement_1"
+                          },
+                          "productListRefNo": {
+                            "S": "123456"
+                          },
+                          "productListUnNo": {
+                            "L": [
+                              {
+                                "S": "123123"
+                              },
+                              {
+                                "S": "987987"
+                              },
+                              {
+                                "S": "135790"
+                              }
+                            ]
+                          },
+                          "productList": {
+                            "S": "productList_1"
+                          }
+                        }
+                      } 
+                    }
+                  },
+                  "vehicleDetails": {
+                    "M": {
+                      "type": {
+                        "S": "Artic tractor"
+                      },
+                      "approvalDate": {
+                        "S": "2023-06-12"
+                      }
+                    }
+                  },
+                  "weight": {
+                    "N": "6789"
+                  }
+                }
+              },  
+          "recordCompleteness": {
+            "S": "88888888"
+          },
+          "createdAt": {
+            "S": "2020-01-01T00:00:00.055Z"
+          },
+          "lastUpdatedAt": {
+            "S": "2020-01-01T00:00:00.000000Z"
+          },
+          "make": {
+            "S": "MAKE"
+          },
+          "model": {
+            "S": "MODEL"
+          },
+          "functionCode": {
+            "S": "1"
+          },
+          "fuelPropulsionSystem": {
+            "S": "DieselPetrol"
+          },
+          "offRoad": {
+            "BOOL": true
+          },
+          "numberOfWheelsDriven": {
+            "N": "1"
+          },
+          "euVehicleCategory": {
+            "S": "m1"
+          },
+          "emissionsLimit": {
+            "N": "1"
+          },
+          "departmentalVehicleMarker": {
+            "BOOL": true
+          },
+          "authIntoService": {
+            "M": {
+              "cocIssueDate": {
+                "S": "2020-01-01"
+              },
+              "dateAuthorised": {
+                "S": "2020-02-02"
+              },
+              "datePending": {
+                "S": "2020-03-03"
+              },
+              "dateReceived": {
+                "S": "2020-04-04"
+              },
+              "dateRejected": {
+                "S": "2020-05-05"
+              }
+            }
+          },
+          "lettersOfAuth": {
+            "M": {
+              "letterType": {
+                "S": "Trailer authorization"
+              },
+              "letterDateRequested": {
+                "S": "2020-01-01"
+              },
+              "letterContents": {
+                "S": "LETTER-CONTENTS"
+              }
+            }
+          },
+          "alterationMarker": {
+            "BOOL": true
+          },
+          "approvalType": {
+            "S": "NTA"
+          },
+          "approvalTypeNumber": {
+            "S": "1"
+          },
+          "variantNumber": {
+            "S": "1"
+          },
+          "variantVersionNumber": {
+            "S": "1"
+          },
+          "grossEecWeight": {
+            "N": "1"
+          },
+          "trainEecWeight": {
+            "N": "1"
+          },
+          "maxTrainEecWeight": {
+            "N": "1"
+          },
+          "applicantDetails": {
+            "M": {
+              "name": {
+                "S": "NAME"
+              },
+              "address1": {
+                "S": "ADDRESS-1"
+              },
+              "address2": {
+                "S": "ADDRESS-2"
+              },
+              "postTown": {
+                "S": "POST-TOWN"
+              },
+              "address3": {
+                "S": "ADDRESS-3"
+              },
+              "postCode": {
+                "S": "POST-CODE"
+              },
+              "emailAddress": {
+                "S": "EMAIL-ADDRESS"
+              },
+              "telephoneNumber": {
+                "S": "TELEPHONE-NUMBER"
+              }
+            }
+          },
+          "purchaserDetails": {
+            "M": {
+              "name": {
+                "S": "NAME"
+              },
+              "address1": {
+                "S": "ADDRESS-1"
+              },
+              "address2": {
+                "S": "ADDRESS-2"
+              },
+              "postTown": {
+                "S": "POST-TOWN"
+              },
+              "address3": {
+                "S": "ADDRESS-3"
+              },
+              "postCode": {
+                "S": "POST-CODE"
+              },
+              "emailAddress": {
+                "S": "EMAIL-ADDRESS"
+              },
+              "telephoneNumber": {
+                "S": "TELEPHONE-NUMBER"
+              },
+              "faxNumber": {
+                "S": "FAX-NUMBER"
+              },
+              "purchaserNotes": {
+                "S": "PURCHASER-NOTES"
+              }
+            }
+          },
+          "manufacturerDetails": {
+            "M": {
+              "name": {
+                "S": "NAME"
+              },
+              "address1": {
+                "S": "ADDRESS-1"
+              },
+              "address2": {
+                "S": "ADDRESS-2"
+              },
+              "postTown": {
+                "S": "POST-TOWN"
+              },
+              "address3": {
+                "S": "ADDRESS-3"
+              },
+              "postCode": {
+                "S": "POST-CODE"
+              },
+              "emailAddress": {
+                "S": "EMAIL-ADDRESS"
+              },
+              "telephoneNumber": {
+                "S": "TELEPHONE-NUMBER"
+              },
+              "faxNumber": {
+                "S": "FAX-NUMBER"
+              },
+              "manufacturerNotes": {
+                "S": "MANUFACTURER-NOTES"
+              }
+            }
+          },
+          "microfilm": {
+            "M": {
+              "microfilmDocumentType": {
+                "S": "PSV Miscellaneous"
+              },
+              "microfilmRollNumber": {
+                "S": "1"
+              },
+              "microfilmSerialNumber": {
+                "S": "1"
+              }
+            }
+          },
+          "plates": {
+            "L": [
+              {
+                "M": {
+                  "plateSerialNumber": {
+                    "S": "1"
+                  },
+                  "plateIssueDate": {
+                    "S": "2020-01-01"
+                  },
+                  "plateReasonForIssue": {
+                    "S": "Free replacement"
+                  },
+                  "plateIssuer": {
+                    "S": "PLATE-ISSUER"
+                  },
+                  "toEmailAddress": {
+                    "S": "TO-EMAIL-ADDRESS"
+                  }
+                }
+              }
+            ]
+          },
+          "chassisMake": {
+            "S": "CHASSIS-MAKE"
+          },
+          "chassisModel": {
+            "S": "CHASSIS-MODEL"
+          },
+          "bodyMake": {
+            "S": "BODY-MAKE"
+          },
+          "bodyModel": {
+            "S": "BODY-MODEL"
+          },
+          "modelLiteral": {
+            "S": "MODEL-LITERAL"
+          },
+          "bodyType": {
+            "M": {
+              "code": {
+                "S": "a"
+              },
+              "description": {
+                "S": "articulated"
+              }
+            }
+          },
+          "manufactureYear": {
+            "N": "2020"
+          },
+          "regnDate": {
+            "S": "2020-01-01"
+          },
+          "firstUseDate": {
+            "S": "2020-01-01"
+          },
+          "coifDate": {
+            "S": "2020-01-01"
+          },
+          "ntaNumber": {
+            "S": "NTA-NUMBER"
+          },
+          "coifSerialNumber": {
+            "S": "88888888"
+          },
+          "coifCertifierName": {
+            "S": "COIF-CERTIFIER-NAME"
+          },
+          "conversionRefNo": {
+            "S": "1010101010"
+          },
+          "seatsLowerDeck": {
+            "N": "1"
+          },
+          "seatsUpperDeck": {
+            "N": "1"
+          },
+          "standingCapacity": {
+            "N": "1"
+          },
+          "speedRestriction": {
+            "N": "1"
+          },
+          "speedLimiterMrk": {
+            "BOOL": true
+          },
+          "tachoExemptMrk": {
+            "BOOL": true
+          },
+          "dispensations": {
+            "S": "DISPENSATIONS"
+          },
+          "remarks": {
+            "S": "REMARKS"
+          },
+          "reasonForCreation": {
+            "S": "REASON-FOR-CREATION"
+          },
+          "statusCode": {
+            "S": "STATUS-CODE"
+          },
+          "unladenWeight": {
+            "N": "1"
+          },
+          "grossKerbWeight": {
+            "N": "1"
+          },
+          "grossLadenWeight": {
+            "N": "1"
+          },
+          "grossGbWeight": {
+            "N": "1"
+          },
+          "grossDesignWeight": {
+            "N": "1"
+          },
+          "trainGbWeight": {
+            "N": "1"
+          },
+          "trainDesignWeight": {
+            "N": "1"
+          },
+          "maxTrainGbWeight": {
+            "N": "1"
+          },
+          "maxTrainDesignWeight": {
+            "N": "1"
+          },
+          "maxLoadOnCoupling": {
+            "N": "1"
+          },
+          "frameDescription": {
+            "S": "Channel section"
+          },
+          "tyreUseCode": {
+            "S": "22"
+          },
+          "roadFriendly": {
+            "BOOL": true
+          },
+          "drawbarCouplingFitted": {
+            "BOOL": true
+          },
+          "euroStandard": {
+            "S": "euroStd"
+          },
+          "suspensionType": {
+            "S": "1"
+          },
+          "couplingType": {
+            "S": "1"
+          },
+          "dimensions": {
+            "M": {
+              "axleSpacing": {
+                "L": [
+                  {
+                    "M": {
+                      "axles": {
+                        "S": "1-2"
+                      },
+                      "value": {
+                        "N": "1"
+                      }
+                    }
+                  }
+                ]
+              },
+              "length": {
+                "N": "1"
+              },
+              "height": {
+                "N": "1"
+              },
+              "width": {
+                "N": "1"
+              }
+            }
+          },
+          "frontAxleTo5thWheelMin": {
+            "N": "1"
+          },
+          "frontAxleTo5thWheelMax": {
+            "N": "1"
+          },
+          "frontVehicleTo5thWheelCouplingMin": {
+            "N": "1"
+          },
+          "frontVehicleTo5thWheelCouplingMax": {
+            "N": "1"
+          },
+          "frontAxleToRearAxle": {
+            "N": "1"
+          },
+          "rearAxleToRearTrl": {
+            "N": "1"
+          },
+          "couplingCenterToRearAxleMin": {
+            "N": "1"
+          },
+          "couplingCenterToRearAxleMax": {
+            "N": "1"
+          },
+          "couplingCenterToRearTrlMin": {
+            "N": "1"
+          },
+          "couplingCenterToRearTrlMax": {
+            "N": "1"
+          },
+          "centreOfRearmostAxleToRearOfTrl": {
+            "N": "1"
+          },
+          "notes": {
+            "S": "NOTES"
+          },
+          "noOfAxles": {
+            "N": "1"
+          },
+          "brakeCode": {
+            "S": "1"
+          },
+          "createdByName": {
+            "S": "CREATED-BY-NAME-2"
+          },
+          "createdById": {
+            "S": "CREATED-BY-ID-2"
+          },
+          "lastUpdatedByName": {
+            "S": "LAST-UPDATED-BY-NAME-2"
+          },
+          "lastUpdatedById": {
+            "S": "LAST-UPDATED-BY-ID-2"
+          },
+          "updateType": {
+            "S": "adrUpdate"
+          },
+          "vehicleClass": {
+            "M": {
+              "code": {
+                "S": "2"
+              },
+              "description": {
+                "S": "motorbikes over 200cc or with a sidecar"
+              }
+            }
+          },
+          "vehicleSubclass": {
+            "L": [
+              {
+                "S": "1"
+              }
+            ]
+          },
+          "vehicleType": {
+            "S": "psv"
+          },
+          "vehicleSize": {
+            "S": "small"
+          },
+          "numberOfSeatbelts": {
+            "S": "NUMBER-OF-SEATBELTS"
+          },
+          "seatbeltInstallationApprovalDate": {
+            "S": "2020-01-01"
+          },
+          "vehicleConfiguration": {
+            "S": "rigid"
+          },
+          "brakes": {
+            "M": {
+              "brakeCodeOriginal": {
+                "S": "333"
+              },
+              "brakeCode": {
+                "S": "666666"
+              },
+              "dataTrBrakeOne": {
+                "S": "DATA-TR-BRAKE-ONE"
+              },
+              "dataTrBrakeTwo": {
+                "S": "DATA-TR-BRAKE-TWO"
+              },
+              "dataTrBrakeThree": {
+                "S": "DATA-TR-BRAKE-THREE"
+              },
+              "retarderBrakeOne": {
+                "S": "electric"
+              },
+              "retarderBrakeTwo": {
+                "S": "electric"
+              },
+              "dtpNumber": {
+                "S": "666666"
+              },
+              "brakeForceWheelsNotLocked": {
+                "M": {
+                  "serviceBrakeForceA": {
+                    "N": "1"
+                  },
+                  "secondaryBrakeForceA": {
+                    "N": "1"
+                  },
+                  "parkingBrakeForceA": {
+                    "N": "1"
+                  }
+                }
+              },
+              "brakeForceWheelsUpToHalfLocked": {
+                "M": {
+                  "serviceBrakeForceB": {
+                    "N": "1"
+                  },
+                  "secondaryBrakeForceB": {
+                    "N": "1"
+                  },
+                  "parkingBrakeForceB": {
+                    "N": "1"
+                  }
+                }
+              },
+              "loadSensingValve": {
+                "BOOL": true
+              },
+              "antilockBrakingSystem": {
+                "BOOL": true
+              }
+            }
+          },
+          "axles": {
+            "L": [
+              {
+                "M": {
+                  "axleNumber": {
+                    "N": "1"
+                  },
+                  "parkingBrakeMrk": {
+                    "BOOL": true
+                  },
+                  "weights": {
+                    "M": {
+                      "kerbWeight": {
+                        "N": "1"
+                      },
+                      "ladenWeight": {
+                        "N": "1"
+                      },
+                      "gbWeight": {
+                        "N": "1"
+                      },
+                      "eecWeight": {
+                        "N": "1"
+                      },
+                      "designWeight": {
+                        "N": "1"
+                      }
+                    }
+                  },
+                  "tyres": {
+                    "M": {
+                      "tyreSize": {
+                        "S": "TYRE-SIZE"
+                      },
+                      "plyRating": {
+                        "S": "22"
+                      },
+                      "fitmentCode": {
+                        "S": "double"
+                      },
+                      "dataTrAxles": {
+                        "N": "1"
+                      },
+                      "speedCategorySymbol": {
+                        "S": "a7"
+                      },
+                      "tyreCode": {
+                        "N": "1"
+                      }
+                    }
+                  },
+                  "brakes": {
+                    "M": {
+                      "brakeActuator": {
+                        "N": "1"
+                      },
+                      "leverLength": {
+                        "N": "1"
+                      },
+                      "springBrakeParking": {
+                        "BOOL": true
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/unit/models/tech-record-document.unitTest.ts
+++ b/tests/unit/models/tech-record-document.unitTest.ts
@@ -80,7 +80,8 @@ describe("parseTechRecordDocument()", () => {
     expect(techRecordDocument.techRecord![0].adrDetails?.documents![1]).toEqual("documents_2");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.listStatementApplicable).toEqual(true);
-    expect(techRecordDocument.techRecord![0].adrDetails?.m145).toEqual(true);
+    expect(techRecordDocument.techRecord![0].adrDetails?.m145Statement).toEqual(true);
+    expect(techRecordDocument.techRecord![0].adrDetails?.newCertificateRequested).toEqual(false);
     
     expect(techRecordDocument.techRecord![0].adrDetails?.memosApply![0]).toEqual("07/09 3mth leak ext");
     
@@ -190,7 +191,8 @@ describe("parseTechRecordDocument()", () => {
     expect(techRecordDocument.techRecord![0].adrDetails?.documents![1]).toEqual("documents_2");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.listStatementApplicable).toEqual(true);
-    expect(techRecordDocument.techRecord![0].adrDetails?.m145).toEqual(true);
+    expect(techRecordDocument.techRecord![0].adrDetails?.m145Statement).toEqual(true);
+    expect(techRecordDocument.techRecord![0].adrDetails?.newCertificateRequested).toEqual(false);
     
     expect(techRecordDocument.techRecord![0].adrDetails?.memosApply![0]).toEqual("07/09 3mth leak ext");
     

--- a/tests/unit/models/tech-record-document.unitTest.ts
+++ b/tests/unit/models/tech-record-document.unitTest.ts
@@ -65,9 +65,9 @@ describe("parseTechRecordDocument()", () => {
     
     expect(techRecordDocument.techRecord![0].adrDetails?.adrTypeApprovalNo).toEqual("adrTypeApprovalNo_1");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails?.name).toEqual("adrDetails_applicantDetails_name_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails?.name).toEqual("applicantDetails_Name");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.batteryListNumber).toEqual("batteryListNumber_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.batteryListNumber).toEqual("BATTERY1");
     expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationIssuer).toEqual("brakeDeclarationIssuer_1");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationsSeen).toEqual(true);
@@ -89,7 +89,7 @@ describe("parseTechRecordDocument()", () => {
     expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![1]).toEqual("Carbon Disulphide");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankManufacturer).toEqual("tankManufacturer_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.yearOfManufacture).toEqual(1234);
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.yearOfManufacture).toEqual(2012);
     expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankCode).toEqual("tankCode_1");
     expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.specialProvisions).toEqual("specialProvisions_1");
     expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankManufacturerSerialNo).toEqual("1234");
@@ -176,9 +176,9 @@ describe("parseTechRecordDocument()", () => {
     
     expect(techRecordDocument.techRecord![0].adrDetails?.adrTypeApprovalNo).toEqual("adrTypeApprovalNo_1");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails?.name).toEqual("adrDetails_applicantDetails_name_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails?.name).toEqual("applicantDetails_Name");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.batteryListNumber).toEqual("batteryListNumber_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.batteryListNumber).toEqual("BATTERY1");
     expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationIssuer).toEqual("brakeDeclarationIssuer_1");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationsSeen).toEqual(true);
@@ -200,7 +200,7 @@ describe("parseTechRecordDocument()", () => {
     expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![1]).toEqual("Carbon Disulphide");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankManufacturer).toEqual("tankManufacturer_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.yearOfManufacture).toEqual(1234);
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.yearOfManufacture).toEqual(2012);
     expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankCode).toEqual("tankCode_1");
     expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.specialProvisions).toEqual("specialProvisions_1");
     expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankManufacturerSerialNo).toEqual("1234");

--- a/tests/unit/models/tech-record-document.unitTest.ts
+++ b/tests/unit/models/tech-record-document.unitTest.ts
@@ -3,11 +3,11 @@ import {
   TechRecordDocument,
 } from "../../../src/models/tech-record-document";
 import { DynamoDbImage } from "../../../src/services/dynamodb-images";
-import { default as techRecordDocumentJson } from "../../resources/dynamodb-image-technical-record.json";
+import { default as techRecordDocumentJson } from "../../resources/dynamodb-image-technical-record-with-adr.json";
 import { castToImageShape } from "../../utils";
 
 describe("parseTechRecordDocument()", () => {
-  it("should successfully parse a DynamoDB image into a TechRecordDocument", () => {
+  it("should successfully parse a DynamoDB image with ADR into a TechRecordDocument", () => {
     const image = DynamoDbImage.parse(castToImageShape(techRecordDocumentJson));
 
     const techRecordDocument: TechRecordDocument = parseTechRecordDocument(
@@ -52,9 +52,72 @@ describe("parseTechRecordDocument()", () => {
       "333"
     );
     expect(techRecordDocument.techRecord![0].axles![0].axleNumber).toEqual(1);
+
+    // ADR Details attributes
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalExaminerNotes![0].note).toEqual("additionalExaminerNotes_note_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalExaminerNotes![0].createdAtDate).toEqual("2023-05-30");
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalExaminerNotes![0].lastUpdatedBy).toEqual("additionalExaminerNotes_lastUpdatedBy_1");
+
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalNotes?.number![0]).toEqual("1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalNotes?.number![1]).toEqual("T1B");
+
+    expect(techRecordDocument.techRecord![0].adrDetails?.adrCertificateNotes).toEqual("adrCertificateNotes_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.adrTypeApprovalNo).toEqual("adrTypeApprovalNo_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails!.name).toEqual("adrDetails_applicantDetails_name_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.batteryListNumber).toEqual("batteryListNumber_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationIssuer).toEqual("brakeDeclarationIssuer_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationsSeen).toEqual(true);
+    expect(techRecordDocument.techRecord![0].adrDetails?.brakeEndurance).toEqual(false);
+    expect(techRecordDocument.techRecord![0].adrDetails?.compatibilityGroupJ).toEqual("I");
+    expect(techRecordDocument.techRecord![0].adrDetails?.dangerousGoods).toEqual(false);
+    expect(techRecordDocument.techRecord![0].adrDetails?.declarationsSeen).toEqual(false);
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.documents![0]).toEqual("documents_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.documents![1]).toEqual("documents_2");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.listStatementApplicable).toEqual(true);
+    expect(techRecordDocument.techRecord![0].adrDetails?.m145).toEqual(true);
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.memosApply![0]).toEqual("07/09 3mth leak ext");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![0]).toEqual("FP <61 (FL)");
+    expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![1]).toEqual("Carbon Disulphide");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankManufacturer).toEqual("tankManufacturer_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.yearOfManufacture).toEqual(1234);
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankCode).toEqual("tankCode_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.specialProvisions).toEqual("specialProvisions_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankManufacturerSerialNo).toEqual("1234");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankTypeAppNo).toEqual("9876");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2Type).toEqual("initial");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2IntermediateApprovalNo).toEqual("12345");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2IntermediateExpiryDate).toEqual("2024-06-01");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3Type).toEqual("intermediate");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3PeriodicNumber).toEqual("98765");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3PeriodicExpiryDate).toEqual("2024-06-01");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.select).toEqual("Product list");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.statement).toEqual("statement_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListRefNo).toEqual("123456");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productList).toEqual("productList_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListUnNo![0]).toEqual("123123");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListUnNo![1]).toEqual("987987");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails!.type).toEqual("Artic tractor");
+    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails!.approvalDate).toEqual("2023-06-12");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.weight).toEqual(6789);
+
   });
 
-  it("should successfully parse a DynamoDB image, with no authIntoService, into a TechRecordDocument", () => {
+  it("should successfully parse a DynamoDB image, with ADR, with no authIntoService, into a TechRecordDocument", () => {
     // @ts-ignore
     delete techRecordDocumentJson.techRecord.L[0].M.authIntoService;
     const image = DynamoDbImage.parse(castToImageShape(techRecordDocumentJson));
@@ -99,5 +162,68 @@ describe("parseTechRecordDocument()", () => {
       "333"
     );
     expect(techRecordDocument.techRecord![0].axles![0].axleNumber).toEqual(1);
+
+    // ADR Details attributes
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalExaminerNotes![0].note).toEqual("additionalExaminerNotes_note_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalExaminerNotes![0].createdAtDate).toEqual("2023-05-30");
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalExaminerNotes![0].lastUpdatedBy).toEqual("additionalExaminerNotes_lastUpdatedBy_1");
+
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalNotes?.number![0]).toEqual("1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.additionalNotes?.number![1]).toEqual("T1B");
+
+    expect(techRecordDocument.techRecord![0].adrDetails?.adrCertificateNotes).toEqual("adrCertificateNotes_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.adrTypeApprovalNo).toEqual("adrTypeApprovalNo_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails!.name).toEqual("adrDetails_applicantDetails_name_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.batteryListNumber).toEqual("batteryListNumber_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationIssuer).toEqual("brakeDeclarationIssuer_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationsSeen).toEqual(true);
+    expect(techRecordDocument.techRecord![0].adrDetails?.brakeEndurance).toEqual(false);
+    expect(techRecordDocument.techRecord![0].adrDetails?.compatibilityGroupJ).toEqual("I");
+    expect(techRecordDocument.techRecord![0].adrDetails?.dangerousGoods).toEqual(false);
+    expect(techRecordDocument.techRecord![0].adrDetails?.declarationsSeen).toEqual(false);
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.documents![0]).toEqual("documents_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.documents![1]).toEqual("documents_2");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.listStatementApplicable).toEqual(true);
+    expect(techRecordDocument.techRecord![0].adrDetails?.m145).toEqual(true);
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.memosApply![0]).toEqual("07/09 3mth leak ext");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![0]).toEqual("FP <61 (FL)");
+    expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![1]).toEqual("Carbon Disulphide");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankManufacturer).toEqual("tankManufacturer_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.yearOfManufacture).toEqual(1234);
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankCode).toEqual("tankCode_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.specialProvisions).toEqual("specialProvisions_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankManufacturerSerialNo).toEqual("1234");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankTypeAppNo).toEqual("9876");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2Type).toEqual("initial");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2IntermediateApprovalNo).toEqual("12345");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2IntermediateExpiryDate).toEqual("2024-06-01");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3Type).toEqual("intermediate");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3PeriodicNumber).toEqual("98765");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3PeriodicExpiryDate).toEqual("2024-06-01");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.select).toEqual("Product list");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.statement).toEqual("statement_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListRefNo).toEqual("123456");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productList).toEqual("productList_1");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListUnNo![0]).toEqual("123123");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListUnNo![1]).toEqual("987987");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails!.type).toEqual("Artic tractor");
+    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails!.approvalDate).toEqual("2023-06-12");
+    
+    expect(techRecordDocument.techRecord![0].adrDetails?.weight).toEqual(6789);
+    
   });
 });

--- a/tests/unit/models/tech-record-document.unitTest.ts
+++ b/tests/unit/models/tech-record-document.unitTest.ts
@@ -65,7 +65,7 @@ describe("parseTechRecordDocument()", () => {
     
     expect(techRecordDocument.techRecord![0].adrDetails?.adrTypeApprovalNo).toEqual("adrTypeApprovalNo_1");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails!.name).toEqual("adrDetails_applicantDetails_name_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails?.name).toEqual("adrDetails_applicantDetails_name_1");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.batteryListNumber).toEqual("batteryListNumber_1");
     expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationIssuer).toEqual("brakeDeclarationIssuer_1");
@@ -87,31 +87,31 @@ describe("parseTechRecordDocument()", () => {
     expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![0]).toEqual("FP <61 (FL)");
     expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![1]).toEqual("Carbon Disulphide");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankManufacturer).toEqual("tankManufacturer_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.yearOfManufacture).toEqual(1234);
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankCode).toEqual("tankCode_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.specialProvisions).toEqual("specialProvisions_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankManufacturerSerialNo).toEqual("1234");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankTypeAppNo).toEqual("9876");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankManufacturer).toEqual("tankManufacturer_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.yearOfManufacture).toEqual(1234);
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankCode).toEqual("tankCode_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.specialProvisions).toEqual("specialProvisions_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankManufacturerSerialNo).toEqual("1234");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankTypeAppNo).toEqual("9876");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2Type).toEqual("initial");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2IntermediateApprovalNo).toEqual("12345");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2IntermediateExpiryDate).toEqual("2024-06-01");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc2Details?.tc2Type).toEqual("initial");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc2Details?.tc2IntermediateApprovalNo).toEqual("12345");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc2Details?.tc2IntermediateExpiryDate).toEqual("2024-06-01");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3Type).toEqual("intermediate");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3PeriodicNumber).toEqual("98765");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3PeriodicExpiryDate).toEqual("2024-06-01");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc3Details![0].tc3Type).toEqual("intermediate");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc3Details![0].tc3PeriodicNumber).toEqual("98765");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc3Details![0].tc3PeriodicExpiryDate).toEqual("2024-06-01");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.select).toEqual("Product list");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.statement).toEqual("statement_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListRefNo).toEqual("123456");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productList).toEqual("productList_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.select).toEqual("Product list");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.statement).toEqual("statement_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.productListRefNo).toEqual("123456");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.productList).toEqual("productList_1");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListUnNo![0]).toEqual("123123");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListUnNo![1]).toEqual("987987");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.productListUnNo![0]).toEqual("123123");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.productListUnNo![1]).toEqual("987987");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails!.type).toEqual("Artic tractor");
-    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails!.approvalDate).toEqual("2023-06-12");
+    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails?.type).toEqual("Artic tractor");
+    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails?.approvalDate).toEqual("2023-06-12");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.weight).toEqual(6789);
 
@@ -175,7 +175,7 @@ describe("parseTechRecordDocument()", () => {
     
     expect(techRecordDocument.techRecord![0].adrDetails?.adrTypeApprovalNo).toEqual("adrTypeApprovalNo_1");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails!.name).toEqual("adrDetails_applicantDetails_name_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.applicantDetails?.name).toEqual("adrDetails_applicantDetails_name_1");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.batteryListNumber).toEqual("batteryListNumber_1");
     expect(techRecordDocument.techRecord![0].adrDetails?.brakeDeclarationIssuer).toEqual("brakeDeclarationIssuer_1");
@@ -197,31 +197,31 @@ describe("parseTechRecordDocument()", () => {
     expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![0]).toEqual("FP <61 (FL)");
     expect(techRecordDocument.techRecord![0].adrDetails?.permittedDangerousGoods![1]).toEqual("Carbon Disulphide");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankManufacturer).toEqual("tankManufacturer_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.yearOfManufacture).toEqual(1234);
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankCode).toEqual("tankCode_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.specialProvisions).toEqual("specialProvisions_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankManufacturerSerialNo).toEqual("1234");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tankTypeAppNo).toEqual("9876");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankManufacturer).toEqual("tankManufacturer_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.yearOfManufacture).toEqual(1234);
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankCode).toEqual("tankCode_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.specialProvisions).toEqual("specialProvisions_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankManufacturerSerialNo).toEqual("1234");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tankTypeAppNo).toEqual("9876");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2Type).toEqual("initial");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2IntermediateApprovalNo).toEqual("12345");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc2Details!.tc2IntermediateExpiryDate).toEqual("2024-06-01");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc2Details?.tc2Type).toEqual("initial");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc2Details?.tc2IntermediateApprovalNo).toEqual("12345");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc2Details?.tc2IntermediateExpiryDate).toEqual("2024-06-01");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3Type).toEqual("intermediate");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3PeriodicNumber).toEqual("98765");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankDetails!.tc3Details![0].tc3PeriodicExpiryDate).toEqual("2024-06-01");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc3Details![0].tc3Type).toEqual("intermediate");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc3Details![0].tc3PeriodicNumber).toEqual("98765");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankDetails?.tc3Details![0].tc3PeriodicExpiryDate).toEqual("2024-06-01");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.select).toEqual("Product list");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.statement).toEqual("statement_1");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListRefNo).toEqual("123456");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productList).toEqual("productList_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.select).toEqual("Product list");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.statement).toEqual("statement_1");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.productListRefNo).toEqual("123456");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.productList).toEqual("productList_1");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListUnNo![0]).toEqual("123123");
-    expect(techRecordDocument.techRecord![0].adrDetails?.tank!.tankStatement!.productListUnNo![1]).toEqual("987987");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.productListUnNo![0]).toEqual("123123");
+    expect(techRecordDocument.techRecord![0].adrDetails?.tank?.tankStatement?.productListUnNo![1]).toEqual("987987");
     
-    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails!.type).toEqual("Artic tractor");
-    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails!.approvalDate).toEqual("2023-06-12");
+    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails?.type).toEqual("Artic tractor");
+    expect(techRecordDocument.techRecord![0].adrDetails?.vehicleDetails?.approvalDate).toEqual("2023-06-12");
     
     expect(techRecordDocument.techRecord![0].adrDetails?.weight).toEqual(6789);
     

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,6 @@
     "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
     "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
     "resolveJsonModule": true,
-    "types": []
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
## Description
Updating the update-store's upsert functionality for ADR attributes so that it stores the ADR Details attributes into NOP tables.

Related issue:
[CB2-10594](https://dvsa.atlassian.net/browse/CB2-10594)
[CB2-10593](https://dvsa.atlassian.net/browse/CB2-10593)
[CB2-10592](https://dvsa.atlassian.net/browse/CB2-10592)

Useful links:
https://dvsa.atlassian.net/wiki/spaces/HVT/pages/382011842/ADR+Section
https://dvsa.atlassian.net/wiki/spaces/HVT/pages/494174610/SPIKE+Validate+existing+update-store+functionality+for+ADR
https://dvsa.atlassian.net/wiki/spaces/HVT/pages/493781660/CB2-10450+-+SPIKE+Compare+NOP+ADR+data+model+to+Dynamo

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
