### PR TITLE
feature(cb2-12587): altered handler to deal with raw messages from sns sqs

### DIFF
--- a/src/functions/process-stream-event.ts
+++ b/src/functions/process-stream-event.ts
@@ -44,7 +44,7 @@ export const processStreamEvent: Handler = async (
 
     for await (const record of event.Records) {
       const id = record.messageId;
-      const dynamoRecord: DynamoDBRecord = JSON.parse(JSON.parse(record.body).Message) as DynamoDBRecord;
+      const dynamoRecord: DynamoDBRecord = JSON.parse(record.body) as DynamoDBRecord;
 
       debugLog('Original DynamoDB stream event body (parsed): ', dynamoRecord);
 

--- a/tests/integration/auth-into-service-document-conversion.intTest.ts
+++ b/tests/integration/auth-into-service-document-conversion.intTest.ts
@@ -71,14 +71,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },
-              })
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },
             }),
           },
         ],
@@ -166,14 +164,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },
-              }),
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },
             }),
           },
         ],
@@ -244,14 +240,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },
-              }),
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },
             }),
           },
         ],
@@ -301,14 +295,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },
-              }),
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },
             }),
           },
         ],
@@ -383,14 +375,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
                 eventSourceARN:
                 "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
                 eventName: "INSERT",
                 dynamodb: {
                   NewImage: techRecordDocumentJsonNew,
                 },
-              })
             }),
           },
         ],
@@ -443,14 +433,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },
-              }),
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },
             }),
           },
         ],
@@ -505,14 +493,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },
-              }),
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },
             }),
           },
         ],
@@ -587,14 +573,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify( {
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },   
-              }),
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },   
            })
           },
         ],

--- a/tests/integration/tech-record-document-conversion.intTest.ts
+++ b/tests/integration/tech-record-document-conversion.intTest.ts
@@ -43,14 +43,12 @@ describe('convertTechRecordDocument() integration tests', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: techRecordDocumentJson,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: techRecordDocumentJson,
+            },
           }),
         },
       ],
@@ -606,14 +604,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },
-              })
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },
             }),
           },
         ],
@@ -654,14 +650,12 @@ describe('convertTechRecordDocument() integration tests', () => {
         Records: [
           {
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventSourceARN:
-                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: techRecordDocumentJsonNew,
-                },
-              })
+              eventSourceARN:
+              "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: techRecordDocumentJsonNew,
+              },
             }),
           },
         ],

--- a/tests/integration/test-results-conversion-with-delete.intTest.ts
+++ b/tests/integration/test-results-conversion-with-delete.intTest.ts
@@ -71,14 +71,12 @@ describe('convertTestResults() integration tests with delete', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJson,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJson,
+            },
           }),
         },
       ],
@@ -346,14 +344,12 @@ describe('convertTestResults() integration tests with delete', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJson,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJson,
+            },
           }),
         },
       ],
@@ -646,14 +642,12 @@ describe('convertTestResults() integration tests with delete', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: serializedJSONb,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: serializedJSONb,
+            },
           }),
         },
       ],
@@ -938,14 +932,12 @@ describe('convertTestResults() integration tests with delete', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: serializedJSONb,
-              },
-            }),
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: serializedJSONb,
+            },
           }),
         }
       ],
@@ -1209,14 +1201,12 @@ describe('convertTestResults() integration tests with delete', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJsonWithTestTypes,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJsonWithTestTypes,
+            },
           }),
         },
       ],
@@ -1529,14 +1519,12 @@ describe('convertTestResults() integration tests with delete', () => {
         {
           messageId: 'faf41ab1-5b42-462c-b242-c4450e15c724',
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJsonWithNoSystemNumber,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJsonWithNoSystemNumber,
+            },
           }),
         },
       ],
@@ -1575,14 +1563,12 @@ describe('convertTestResults() integration tests with delete', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJsonWithoutTestTypes,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJsonWithoutTestTypes,
+            },
           }),
         },
       ],

--- a/tests/integration/test-results-conversion-with-upsert.intTest.ts
+++ b/tests/integration/test-results-conversion-with-upsert.intTest.ts
@@ -71,14 +71,12 @@ describe('convertTestResults() integration tests with upsert', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJson,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJson,
+            },
           }),
         },
       ],
@@ -346,14 +344,12 @@ describe('convertTestResults() integration tests with upsert', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJson,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJson,
+            },
           }),
         },
       ],
@@ -646,14 +642,12 @@ describe('convertTestResults() integration tests with upsert', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: serializedJSONb,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: serializedJSONb,
+            },
           }),
         },
       ],
@@ -938,14 +932,12 @@ describe('convertTestResults() integration tests with upsert', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: serializedJSONb,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: serializedJSONb,
+            },
           }),
         },
       ],
@@ -1209,14 +1201,12 @@ describe('convertTestResults() integration tests with upsert', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJsonWithTestTypes,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJsonWithTestTypes,
+            },
           }),
         },
       ],
@@ -1529,14 +1519,12 @@ describe('convertTestResults() integration tests with upsert', () => {
         {
           messageId: 'faf41ab1-5b42-462c-b242-c4450e15c724',
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJsonWithNoSystemNumber,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJsonWithNoSystemNumber,
+            },
           }),
         },
       ],
@@ -1575,14 +1563,12 @@ describe('convertTestResults() integration tests with upsert', () => {
       Records: [
         {
           body: JSON.stringify({
-            Message: JSON.stringify({
-              eventSourceARN:
-              "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
-              eventName: "INSERT",
-              dynamodb: {
-                NewImage: testResultsJsonWithoutTestTypes,
-              },
-            })
+            eventSourceARN:
+            "arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000",
+            eventName: "INSERT",
+            dynamodb: {
+              NewImage: testResultsJsonWithoutTestTypes,
+            },
           }),
         },
       ],

--- a/tests/unit/functions/process-stream-event.unitTest.ts
+++ b/tests/unit/functions/process-stream-event.unitTest.ts
@@ -22,15 +22,13 @@ describe('processStreamEvent()', () => {
         {
           Records: [
             {
-              body: JSON.stringify({
-                Message: JSON.stringify({
-                  eventName: "INSERT",
-                  dynamodb: {
-                    NewImage: {},
-                  },
-                  eventSourceARN:
-                    "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-                })
+              body: JSON.stringify({      
+                eventName: "INSERT",
+                dynamodb: {
+                  NewImage: {},
+                },
+                eventSourceARN:
+                  "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
               }),
             },
           ],
@@ -189,40 +187,34 @@ describe('processStreamEvent()', () => {
           {
             messageId: 'SUCCESS',
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: {},
-                },
-                eventSourceARN:
-                  "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",           
-              })
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: {},
+              },
+              eventSourceARN:
+                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
             }),
           },
           {
             messageId: 'FAILURE',
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: {},
-                },
-                eventSourceARN:
-                  "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-              })
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: {},
+              },
+              eventSourceARN:
+                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
             }),
           },
           {
             messageId: 'SUCCESS',
             body: JSON.stringify({
-              Message: JSON.stringify({
-                eventName: "INSERT",
-                dynamodb: {
-                  NewImage: {},
-                },
-                eventSourceARN:
-                  "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
-              })
+              eventName: "INSERT",
+              dynamodb: {
+                NewImage: {},
+              },
+              eventSourceARN:
+                "arn:aws:dynamodb:eu-west-1:1:table/technical-records/stream/2020-01-01T00:00:00.000",
             }),
           },
         ],


### PR DESCRIPTION
## Description

The handler now deals with messages from the SNS/SQS pairs that it subscribes to in a raw format meaning that it no longer needs to deal with double JSON encoded messages.

Related issue: [CB2-12587](https://dvsa.atlassian.net/browse/CB2-12587)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
