### PR TITLE
feat(CB2-13178): added in vef to the test station types array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-dynamodb-streams": "3.577.0",
         "@aws-sdk/client-secrets-manager": "3.565.0",
         "@aws-sdk/util-dynamodb": "3.577.0",
-        "@dvsa/cvs-type-definitions": "^7.2.0",
+        "@dvsa/cvs-type-definitions": "^7.4.0",
         "@types/lambda-tester": "4.0.3",
         "aws-xray-sdk": "3.6.0",
         "date-fns": "3.6.0",
@@ -7419,9 +7419,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.2.0.tgz",
-      "integrity": "sha512-xgJ1WpIpKkUkKrCtle9OqDbnmpm9VZ8ePdl+QPvayRHxGpDgLTTgj9wyhsz9+XW2bqOepAGbBM1jO+JMPLZAog==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.4.0.tgz",
+      "integrity": "sha512-MGiIQ2It0xBlu9n+RqgrnlEpsHWUoZFPqIGF4VcaMpTCgVzcNE9TriuJMmdGI6TiegzxByOIhYNNtjQYQ1x5cA==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@aws-sdk/client-dynamodb-streams": "3.577.0",
     "@aws-sdk/client-secrets-manager": "3.565.0",
     "@aws-sdk/util-dynamodb": "3.577.0",
+    "@dvsa/cvs-type-definitions": "^7.4.0",
     "@types/lambda-tester": "4.0.3",
     "aws-xray-sdk": "3.6.0",
     "date-fns": "3.6.0",

--- a/src/models/test-results.ts
+++ b/src/models/test-results.ts
@@ -8,7 +8,7 @@ import {
 } from './shared-enums';
 import { DynamoDbImage, parseStringArray } from '../services/dynamodb-images';
 import { debugLog } from '../services/logger';
-import {TestStationTypes} from "@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum";
+import { TestStationTypes } from "@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum";
 
 export type TestVersion = 'current' | 'archived';
 

--- a/src/models/test-results.ts
+++ b/src/models/test-results.ts
@@ -11,7 +11,7 @@ import { debugLog } from '../services/logger';
 
 export type TestVersion = 'current' | 'archived';
 
-export type TestStationType = 'atf' | 'gvts' | 'hq';
+export type TestStationType = 'atf' | 'gvts' | 'hq' | 'vef';
 
 export type TestStatus = 'submitted' | 'cancelled';
 

--- a/src/models/test-results.ts
+++ b/src/models/test-results.ts
@@ -8,10 +8,9 @@ import {
 } from './shared-enums';
 import { DynamoDbImage, parseStringArray } from '../services/dynamodb-images';
 import { debugLog } from '../services/logger';
+import {TestStationTypes} from "@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum";
 
 export type TestVersion = 'current' | 'archived';
-
-export type TestStationType = 'atf' | 'gvts' | 'hq' | 'vef';
 
 export type TestStatus = 'submitted' | 'cancelled';
 
@@ -37,7 +36,7 @@ export interface TestResult {
   shouldEmailCertificate?: string;
   testStationName?: string;
   testStationPNumber?: string;
-  testStationType?: TestStationType;
+  testStationType?: TestStationTypes;
   testerName?: string;
   testerStaffId?: string;
   testResultId?: string;
@@ -98,7 +97,7 @@ export const parseTestResult = (image: DynamoDbImage): TestResult => ({
   shouldEmailCertificate: image.getString('shouldEmailCertificate'),
   testStationName: image.getString('testStationName'),
   testStationPNumber: image.getString('testStationPNumber'),
-  testStationType: image.getString('testStationType') as TestStationType,
+  testStationType: image.getString('testStationType') as TestStationTypes,
   testerName: image.getString('testerName'),
   testerStaffId: image.getString('testerStaffId'),
   testResultId: image.getString('testResultId'),


### PR DESCRIPTION
## Update any local usages of test station type to the centralised type-definition list, to allow 'vef' to be processed

Update to the test station type to include the test station type VEF

Related issue: [CB2-13439](https://dvsa.atlassian.net/browse/CB2-13439)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
