### PR TITLE
feature/CB2-13302 - VRM time of test

### DIFF
--- a/src/models/test-results.ts
+++ b/src/models/test-results.ts
@@ -1,3 +1,4 @@
+import { TestStationTypes } from '@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum';
 import { parseVehicleClass, VehicleClass } from './vehicle-class';
 import { parseTestTypes, TestTypes } from './test-types';
 import {
@@ -8,7 +9,6 @@ import {
 } from './shared-enums';
 import { DynamoDbImage, parseStringArray } from '../services/dynamodb-images';
 import { debugLog } from '../services/logger';
-import { TestStationTypes } from "@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum";
 
 export type TestVersion = 'current' | 'archived';
 

--- a/src/models/test-results.ts
+++ b/src/models/test-results.ts
@@ -1,4 +1,3 @@
-import { TestStationTypes } from '@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum';
 import { parseVehicleClass, VehicleClass } from './vehicle-class';
 import { parseTestTypes, TestTypes } from './test-types';
 import {
@@ -9,6 +8,7 @@ import {
 } from './shared-enums';
 import { DynamoDbImage, parseStringArray } from '../services/dynamodb-images';
 import { debugLog } from '../services/logger';
+import { TestStationTypes } from "@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum";
 
 export type TestVersion = 'current' | 'archived';
 

--- a/src/services/table-details.ts
+++ b/src/services/table-details.ts
@@ -361,6 +361,7 @@ export const TEST_RESULT_TABLE: TableDetails = {
     'createdBy_Id',
     'lastUpdatedBy_Id',
     'nopInsertedAt',
+    'vrm_trm',
   ],
 };
 

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -77,9 +77,6 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
       if (existingVehicleRecordIds.rows.length > 0) {
         vehicleId = existingVehicleRecordIds.rows[0].id;
       } else {
-        // Throw here to avoid since we are in a try catch anyway.
-        // and so can avoid having to move all the code that relies on vehicleId being set
-        // within this if statement.
         debugLog(`upserting vehicle as no associated vehicle record was found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)}`);
         vehicleId = await upsertVehicle(vehicleConnection, testResult);
       }

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -80,7 +80,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
         // Throw here to avoid since we are in a try catch anyway.
         // and so can avoid having to move all the code that relies on vehicleId being set
         // within this if statement.
-        debugLog(`upserting vehicle as no associated vehicle record was found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)} could be found.`);
+        debugLog(`upserting vehicle as no associated vehicle record was found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)}`);
         vehicleId = await upsertVehicle(vehicleConnection, testResult);
       }
 

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -80,7 +80,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
         // Throw here to avoid since we are in a try catch anyway.
         // and so can avoid having to move all the code that relies on vehicleId being set
         // within this if statement.
-        debugLog(`upserting vehicle as associated vehicle record found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)} could be found.`);
+        debugLog(`upserting vehicle as no associated vehicle record was found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)} could be found.`);
         vehicleId = await upsertVehicle(vehicleConnection, testResult);
       }
 

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -68,7 +68,21 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
       );
       await vehicleConnection.beginTransaction();
 
-      vehicleId = await upsertVehicle(vehicleConnection, testResult);
+      const existingVehicleRecordIds = await selectRecordIds(
+        VEHICLE_TABLE.tableName,
+        { system_number: testResult.systemNumber, vin: vinCleanser(testResult.vin) },
+        vehicleConnection,
+      );
+
+      if (existingVehicleRecordIds.rows.length > 0) {
+        vehicleId = existingVehicleRecordIds.rows[0].id;
+      } else {
+        // Throw here to avoid since we are in a try catch anyway.
+        // and so can avoid having to move all the code that relies on vehicleId being set
+        // within this if statement.
+        debugLog(`upserting vehicle as associated vehicle record found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)} could be found.`);
+        vehicleId = await upsertVehicle(vehicleConnection, testResult);
+      }
 
       await vehicleConnection.commit();
     } catch (err) {
@@ -157,6 +171,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
             createdById,
             lastUpdatedById,
             moment().format('YYYY-MM-DD HH:mm:ss.SSS'),
+            testResult.vrm,
           ],
           testResultConnection,
         );
@@ -254,6 +269,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
             createdById,
             lastUpdatedById,
             moment().format('YYYY-MM-DD HH:mm:ss.SSS'),
+            testResult.vrm,
           ],
           testResultConnection,
         );


### PR DESCRIPTION
## Description

Encompasses small changes made to update store to accommodate for vrm being recorded at time of test on a test result (see [CB2-13302](https://dvsa.atlassian.net/browse/CB2-13302)). 

Note that despite the below ticket of work suggesting we delete the upsert to the vehicle table all together - this caused some tests to fail. By upserting only in the case that no vehicle existed with that system number and vin, these tests then passed. 
- Upserting is only done in this case, otherwise we select the vehicle id from the vehicle table.

Related issue: [CB2-13302](https://dvsa.atlassian.net/browse/CB2-13302)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[CB2-13302]: https://dvsa.atlassian.net/browse/CB2-13302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB2-13302]: https://dvsa.atlassian.net/browse/CB2-13302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ