### PR TITLE
Feature/CB2-13302 - Add VRM at time of test to test result table in NOP

### DIFF
--- a/src/models/test-results.ts
+++ b/src/models/test-results.ts
@@ -1,3 +1,4 @@
+import { TestStationTypes } from '@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum';
 import { parseVehicleClass, VehicleClass } from './vehicle-class';
 import { parseTestTypes, TestTypes } from './test-types';
 import {
@@ -8,7 +9,6 @@ import {
 } from './shared-enums';
 import { DynamoDbImage, parseStringArray } from '../services/dynamodb-images';
 import { debugLog } from '../services/logger';
-import { TestStationTypes } from "@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum";
 
 export type TestVersion = 'current' | 'archived';
 

--- a/src/models/test-results.ts
+++ b/src/models/test-results.ts
@@ -1,4 +1,3 @@
-import { TestStationTypes } from '@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum';
 import { parseVehicleClass, VehicleClass } from './vehicle-class';
 import { parseTestTypes, TestTypes } from './test-types';
 import {
@@ -9,6 +8,7 @@ import {
 } from './shared-enums';
 import { DynamoDbImage, parseStringArray } from '../services/dynamodb-images';
 import { debugLog } from '../services/logger';
+import { TestStationTypes } from "@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum";
 
 export type TestVersion = 'current' | 'archived';
 

--- a/src/services/table-details.ts
+++ b/src/services/table-details.ts
@@ -361,6 +361,7 @@ export const TEST_RESULT_TABLE: TableDetails = {
     'createdBy_Id',
     'lastUpdatedBy_Id',
     'nopInsertedAt',
+    'vrm_trm',
   ],
 };
 

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -77,9 +77,6 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
       if (existingVehicleRecordIds.rows.length > 0) {
         vehicleId = existingVehicleRecordIds.rows[0].id;
       } else {
-        // Throw here to avoid since we are in a try catch anyway.
-        // and so can avoid having to move all the code that relies on vehicleId being set
-        // within this if statement.
         debugLog(`upserting vehicle as no associated vehicle record was found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)}`);
         vehicleId = await upsertVehicle(vehicleConnection, testResult);
       }

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -80,7 +80,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
         // Throw here to avoid since we are in a try catch anyway.
         // and so can avoid having to move all the code that relies on vehicleId being set
         // within this if statement.
-        debugLog(`upserting vehicle as no associated vehicle record was found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)} could be found.`);
+        debugLog(`upserting vehicle as no associated vehicle record was found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)}`);
         vehicleId = await upsertVehicle(vehicleConnection, testResult);
       }
 

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -80,7 +80,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
         // Throw here to avoid since we are in a try catch anyway.
         // and so can avoid having to move all the code that relies on vehicleId being set
         // within this if statement.
-        debugLog(`upserting vehicle as associated vehicle record found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)} could be found.`);
+        debugLog(`upserting vehicle as no associated vehicle record was found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)} could be found.`);
         vehicleId = await upsertVehicle(vehicleConnection, testResult);
       }
 

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -68,7 +68,21 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
       );
       await vehicleConnection.beginTransaction();
 
-      vehicleId = await upsertVehicle(vehicleConnection, testResult);
+      const existingVehicleRecordIds = await selectRecordIds(
+        VEHICLE_TABLE.tableName,
+        { system_number: testResult.systemNumber, vin: vinCleanser(testResult.vin) },
+        vehicleConnection,
+      );
+
+      if (existingVehicleRecordIds.rows.length > 0) {
+        vehicleId = existingVehicleRecordIds.rows[0].id;
+      } else {
+        // Throw here to avoid since we are in a try catch anyway.
+        // and so can avoid having to move all the code that relies on vehicleId being set
+        // within this if statement.
+        debugLog(`upserting vehicle as associated vehicle record found for testResult with systemNumber: ${testResult.systemNumber} and vin: ${vinCleanser(testResult.vin)} could be found.`);
+        vehicleId = await upsertVehicle(vehicleConnection, testResult);
+      }
 
       await vehicleConnection.commit();
     } catch (err) {
@@ -157,6 +171,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
             createdById,
             lastUpdatedById,
             moment().format('YYYY-MM-DD HH:mm:ss.SSS'),
+            testResult.vrm,
           ],
           testResultConnection,
         );
@@ -254,6 +269,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
             createdById,
             lastUpdatedById,
             moment().format('YYYY-MM-DD HH:mm:ss.SSS'),
+            testResult.vrm,
           ],
           testResultConnection,
         );

--- a/tests/integration/test-results-conversion-with-upsert.intTest.ts
+++ b/tests/integration/test-results-conversion-with-upsert.intTest.ts
@@ -113,7 +113,7 @@ describe('convertTestResults() integration tests with upsert', () => {
                   \`fuel_emission_id\`, \`test_type_id\`, \`id\`, \`testResultId\`, \`testCode\`,  \`certificateNumber\`,  \`secondaryCertificateNumber\`,
                   \`testExpiryDate\`,  \`testAnniversaryDate\`,  \`testTypeStartTimestamp\`,  \`numberOfSeatbeltsFitted\`, \`lastSeatbeltInstallationCheckDate\`,
                   \`seatbeltInstallationCheckDate\`,  \`testResult\`,  \`reasonForAbandoning\`,  \`additionalNotesRecorded\`,  \`additionalCommentsForAbandon\`,
-                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`
+                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`, \`vrm_trm\`
           FROM \`test_result\`
           WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}`,
     );
@@ -156,6 +156,9 @@ describe('convertTestResults() integration tests with upsert', () => {
     );
     expect(testResultSet.rows[0].smokeTestKLimitApplied).toBe(
       'SMOKE-TEST-K-LIMIT-APPLIED',
+    );
+    expect(testResultSet.rows[0].vrm_trm).toBe(
+      'VRM-5',
     );
 
     expect(testResultSet.rows).toHaveLength(1);
@@ -390,7 +393,7 @@ describe('convertTestResults() integration tests with upsert', () => {
                   \`fuel_emission_id\`, \`test_type_id\`, \`id\`, \`testResultId\`, \`testCode\`,  \`certificateNumber\`,  \`secondaryCertificateNumber\`,
                   \`testExpiryDate\`,  \`testAnniversaryDate\`,  \`testTypeStartTimestamp\`,  \`numberOfSeatbeltsFitted\`, \`lastSeatbeltInstallationCheckDate\`,
                   \`seatbeltInstallationCheckDate\`,  \`testResult\`,  \`reasonForAbandoning\`,  \`additionalNotesRecorded\`,  \`additionalCommentsForAbandon\`,
-                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`
+                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`, \`vrm_trm\`
           FROM \`test_result\`
           WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}`,
     );
@@ -433,6 +436,9 @@ describe('convertTestResults() integration tests with upsert', () => {
     );
     expect(testResultSet.rows[0].smokeTestKLimitApplied).toBe(
       'SMOKE-TEST-K-LIMIT-APPLIED',
+    );
+    expect(testResultSet.rows[0].vrm_trm).toBe(
+      'VRM-5',
     );
 
     expect(testResultSet.rows).toHaveLength(1);
@@ -683,7 +689,7 @@ describe('convertTestResults() integration tests with upsert', () => {
                   \`fuel_emission_id\`, \`test_type_id\`, \`id\`, \`testResultId\`, \`testCode\`,  \`certificateNumber\`,  \`secondaryCertificateNumber\`,
                   \`testExpiryDate\`,  \`testAnniversaryDate\`,  \`testTypeStartTimestamp\`,  \`numberOfSeatbeltsFitted\`, \`lastSeatbeltInstallationCheckDate\`,
                   \`seatbeltInstallationCheckDate\`,  \`testResult\`,  \`reasonForAbandoning\`,  \`additionalNotesRecorded\`,  \`additionalCommentsForAbandon\`,
-                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`
+                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`, \`vrm_trm\`
           FROM \`test_result\`
           WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}`,
     );
@@ -723,6 +729,9 @@ describe('convertTestResults() integration tests with upsert', () => {
     );
     expect(testResultSet.rows[0].smokeTestKLimitApplied).toBe(
       'NEW-SMOKE-TEST-K-LIMIT-APPLIED',
+    );
+    expect(testResultSet.rows[0].vrm_trm).toBe(
+      'VRM-5',
     );
 
     const {
@@ -973,12 +982,12 @@ describe('convertTestResults() integration tests with upsert', () => {
                   \`fuel_emission_id\`, \`test_type_id\`, \`id\`, \`testResultId\`, \`testCode\`,  \`certificateNumber\`,  \`secondaryCertificateNumber\`,
                   \`testExpiryDate\`,  \`testAnniversaryDate\`,  \`testTypeStartTimestamp\`,  \`numberOfSeatbeltsFitted\`, \`lastSeatbeltInstallationCheckDate\`,
                   \`seatbeltInstallationCheckDate\`,  \`testResult\`,  \`reasonForAbandoning\`,  \`additionalNotesRecorded\`,  \`additionalCommentsForAbandon\`,
-                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`
+                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`, \`vrm_trm\`
           FROM \`test_result\`
           WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}`,
     );
 
-    expect(testResultSet.rows[0].testResultId).toBe('TEST-RESULT-ID-5-U');
+    expect(testResultSet.rows[0].vrm_trm).toBe('VRM-5');
     expect(testResultSet.rows).toHaveLength(2);
     expect(testResultSet.rows[0].testCode).toBe('555');
     expect(testResultSet.rows[0].certificateNumber).toBe('W43434343');
@@ -1013,6 +1022,9 @@ describe('convertTestResults() integration tests with upsert', () => {
     );
     expect(testResultSet.rows[0].smokeTestKLimitApplied).toBe(
       'NEW-SMOKE-TEST-K-LIMIT-APPLIED',
+    );
+    expect(testResultSet.rows[0].vrm_trm).toBe(
+      'VRM-5',
     );
 
     const {
@@ -1242,7 +1254,7 @@ describe('convertTestResults() integration tests with upsert', () => {
                   \`fuel_emission_id\`, \`test_type_id\`, \`id\`, \`testResultId\`, \`testCode\`,  \`certificateNumber\`,  \`secondaryCertificateNumber\`,
                   \`testExpiryDate\`,  \`testAnniversaryDate\`,  \`testTypeStartTimestamp\`,  \`numberOfSeatbeltsFitted\`, \`lastSeatbeltInstallationCheckDate\`,
                   \`seatbeltInstallationCheckDate\`,  \`testResult\`,  \`reasonForAbandoning\`,  \`additionalNotesRecorded\`,  \`additionalCommentsForAbandon\`,
-                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`, \`testTypeEndTimestamp\`
+                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`, \`testTypeEndTimestamp\`, \`vrm_trm\`
           FROM \`test_result\`
           WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}
           ORDER BY id ASC`,
@@ -1290,6 +1302,9 @@ describe('convertTestResults() integration tests with upsert', () => {
     );
     expect(testResultSet.rows[0].smokeTestKLimitApplied).toBe(
       'SMOKE-TEST-K-LIMIT-APPLIED',
+    );
+    expect(testResultSet.rows[0].vrm_trm).toBe(
+      'VRM-3',
     );
 
     expect(testResultSet.rows[1].testResultId).toBe('TEST-RESULT-ID-3-U');
@@ -1604,14 +1619,13 @@ describe('convertTestResults() integration tests with upsert', () => {
                   \`fuel_emission_id\`, \`test_type_id\`, \`id\`, \`testResultId\`, \`testCode\`,  \`certificateNumber\`,  \`secondaryCertificateNumber\`,
                   \`testExpiryDate\`,  \`testAnniversaryDate\`,  \`testTypeStartTimestamp\`,  \`numberOfSeatbeltsFitted\`, \`lastSeatbeltInstallationCheckDate\`,
                   \`seatbeltInstallationCheckDate\`,  \`testResult\`,  \`reasonForAbandoning\`,  \`additionalNotesRecorded\`,  \`additionalCommentsForAbandon\`,
-                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`, \`testTypeEndTimestamp\`
+                  \`particulateTrapFitted\`,  \`particulateTrapSerialNumber\`,  \`modificationTypeUsed\`, \`smokeTestKLimitApplied\`, \`testTypeEndTimestamp\`, \`vrm_trm\`
           FROM \`test_result\`
           WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}
           ORDER BY id ASC`,
     );
 
     expect(testResultSet.rows).toHaveLength(1);
-
     expect(testResultSet.rows[0].testResultId).toBe('TEST-RESULT-ID-4-U');
     expect(testResultSet.rows[0].testCode).toBeNull();
     expect(testResultSet.rows[0].certificateNumber).toBeNull();
@@ -1631,6 +1645,7 @@ describe('convertTestResults() integration tests with upsert', () => {
     expect(testResultSet.rows[0].particulateTrapSerialNumber).toBeNull();
     expect(testResultSet.rows[0].modificationTypeUsed).toBeNull();
     expect(testResultSet.rows[0].smokeTestKLimitApplied).toBeNull();
+    expect(testResultSet.rows[0].vrm_trm).toBe("VRM-4");
 
     const {
       test_station_id,

--- a/tests/integration/test-results-conversion-with-upsert.intTest.ts
+++ b/tests/integration/test-results-conversion-with-upsert.intTest.ts
@@ -1056,6 +1056,7 @@ describe('convertTestResults() integration tests with upsert', () => {
           WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}`,
     );
 
+    expect(testResultSet.rows[0].testResultId).toBe('TEST-RESULT-ID-5-U');
     expect(testResultSet.rows[0].vrm_trm).toBe('VRM-5');
     expect(testResultSet.rows).toHaveLength(2);
     expect(testResultSet.rows[0].testCode).toBe('555');

--- a/tests/integration/test-results-conversion-with-upsert.intTest.ts
+++ b/tests/integration/test-results-conversion-with-upsert.intTest.ts
@@ -33,6 +33,7 @@ describe('convertTestResults() integration tests with upsert', () => {
       require('../resources/dynamodb-image-test-results-without-testtypes.json'),
     ),
   );
+
   testResultsJson.testResultId.S = `${testResultsJson.testResultId.S}-U`;
   testResultsJson.systemNumber.S = `${testResultsJson.systemNumber.S}-U`;
   testResultsJsonWithTestTypes.testResultId.S = `${testResultsJsonWithTestTypes.testResultId.S}-U`;
@@ -40,6 +41,16 @@ describe('convertTestResults() integration tests with upsert', () => {
   testResultsJsonWithNoSystemNumber.testResultId.S = `${testResultsJsonWithNoSystemNumber.testResultId.S}-U`;
   testResultsJsonWithoutTestTypes.testResultId.S = `${testResultsJsonWithoutTestTypes.testResultId.S}-U`;
   testResultsJsonWithoutTestTypes.systemNumber.S = `${testResultsJsonWithoutTestTypes.systemNumber.S}-U`;
+
+  // This test case is needed to ensure that VRM changes on a test-result do not get propagated
+  // to the vehicle table - assuming a vehicle already exists with that system number, vin combination
+  const testResultsJsonWithDifferentVrm = JSON.parse(
+    // This feels easier than creating an entirely new test case JSON file that only differs on VRM
+    JSON.stringify(require('../resources/dynamodb-image-test-results.json')).replace("VRM-5", "VRM-6"),
+  );
+  // Ensure system number and rest result id allign with testResultsJson test case as well
+  testResultsJsonWithDifferentVrm.testResultId.S = `${testResultsJsonWithDifferentVrm.testResultId.S}-U`;
+  testResultsJsonWithDifferentVrm.systemNumber.S = `${testResultsJsonWithDifferentVrm.systemNumber.S}-U`;
 
   beforeAll(async () => {
     process.env.DISABLE_DELETE_ON_UPDATE = 'true';
@@ -342,6 +353,62 @@ describe('convertTestResults() integration tests with upsert', () => {
     ).toBe('DEFECT-NOTES-5');
   });
 
+  it('should not overwrite the vrm on the existing vehicle when the VRM changes on a test result', async () => {
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            eventSourceARN:
+            'arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000',
+            eventName: 'INSERT',
+            dynamodb: {
+            NewImage: testResultsJsonWithDifferentVrm,
+            },
+          }),
+        },
+      ],
+    };
+
+    const consoleSpy = jest
+      .spyOn(global.console, 'error')
+      .mockImplementation();
+
+    await processStreamEvent(event, exampleContext(), () => {
+
+    });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(0);
+
+    const vehicleResultSet = await executeSql(
+      `SELECT \`system_number\`, \`vin\`, \`vrm_trm\`, \`trailer_id\`, \`createdAt\`, \`id\`
+            FROM \`vehicle\`
+            WHERE \`vehicle\`.\`id\` IN (
+              SELECT \`id\`
+              FROM \`vehicle\`
+              WHERE \`vehicle\`.\`system_number\` = "${testResultsJsonWithDifferentVrm.systemNumber.S}"
+            )`,
+    );
+
+    expect(vehicleResultSet.rows).toHaveLength(1);
+    expect(vehicleResultSet.rows[0].system_number).toBe(
+      'SYSTEM-NUMBER-5-U',
+    );
+    expect(vehicleResultSet.rows[0].vin).toBe('VIN5');
+    // Expect the VRM on the vehicle table to be unchanged from previous test case
+    expect(vehicleResultSet.rows[0].vrm_trm).toBe('VRM-5');
+
+    const testResultSet = await executeSql(
+      `SELECT \`vrm_trm\`
+          FROM \`test_result\`
+          WHERE \`test_result\`.\`vehicle_id\` = ${vehicleResultSet.rows[0].id}`,
+    );
+
+    // But, expect the VRM on the test result to be changed
+    expect(testResultSet.rows[0].vrm_trm).toBe(
+      'VRM-6',
+    );
+
+  });
   it('should correctly convert a DynamoDB event into Aurora rows when processed a second time', async () => {
     const event = {
       Records: [
@@ -437,6 +504,8 @@ describe('convertTestResults() integration tests with upsert', () => {
     expect(testResultSet.rows[0].smokeTestKLimitApplied).toBe(
       'SMOKE-TEST-K-LIMIT-APPLIED',
     );
+
+    // But, expect the VRM on the test result to be changed
     expect(testResultSet.rows[0].vrm_trm).toBe(
       'VRM-5',
     );
@@ -1771,7 +1840,7 @@ describe('convertTestResults() integration tests with upsert', () => {
               WHERE testResultId like '%-U';`,
     );
 
-    expect(customDefectResultSet.rows).toHaveLength(5);
+    expect(customDefectResultSet.rows).toHaveLength(6);
 
     const testTypeResultSet = await executeSql(
       `SELECT DISTINCT tt.id FROM test_type tt

--- a/tests/unit/services/entity-conversion.unitTest.ts
+++ b/tests/unit/services/entity-conversion.unitTest.ts
@@ -1,8 +1,6 @@
 import { techRecordDocumentConverter } from '../../../src/services/tech-record-document-conversion';
 import { convert } from '../../../src/services/entity-conversion';
 import { DynamoDbImage } from '../../../src/services/dynamodb-images';
-import { testResultsConverter } from '../../../src/services/test-result-record-conversion';
-import { selectRecordIds } from '../../../src/services/sql-execution';
 
 jest.mock('../../../src/services/tech-record-document-conversion', () => ({
   techRecordDocumentConverter: jest.fn().mockReturnValue({
@@ -52,38 +50,3 @@ describe('convert()', () => {
     },
   });
 });
-
-// jest.mock('../../../src/services/test-result-record-conversion.ts', () => ({
-//   testResultsConverter: jest.fn().mockReturnValue({
-//     parseRootImage: jest.fn(),
-//     upsertEntity: jest.fn(),
-//     deleteEntity: jest.fn(),
-//   }),
-// }));
-//
-// // Mock sql-execution so that it always returns one row
-// jest.mock('../../../src/services/sql-execution.ts', () => ({
-//   selectRecordIds: jest.fn().mockReturnValue({
-//     rows: [1]
-//   })
-// }));
-//
-// describe('upsertTestResults()', () => {
-//   beforeEach(() => {
-//     // techRecordDocumentConverter().parseRootImage.mockReset();
-//     // techRecordDocumentConverter().upsertEntity.mockReset();
-//     // techRecordDocumentConverter().deleteEntity.mockReset();
-//   });
-//
-//   it("should be ", () => {
-//     convert('technical-records', 'INSERT', exampleImage());
-//
-//     expect(techRecordDocumentConverter().parseRootImage).toHaveBeenCalledTimes(
-//       1,
-//     );
-//     expect(techRecordDocumentConverter().upsertEntity).toHaveBeenCalledTimes(1);
-//     expect(techRecordDocumentConverter().deleteEntity).toHaveBeenCalledTimes(0);
-//   });
-//
-//
-//

--- a/tests/unit/services/entity-conversion.unitTest.ts
+++ b/tests/unit/services/entity-conversion.unitTest.ts
@@ -1,6 +1,8 @@
 import { techRecordDocumentConverter } from '../../../src/services/tech-record-document-conversion';
 import { convert } from '../../../src/services/entity-conversion';
 import { DynamoDbImage } from '../../../src/services/dynamodb-images';
+import { testResultsConverter } from '../../../src/services/test-result-record-conversion';
+import { selectRecordIds } from '../../../src/services/sql-execution';
 
 jest.mock('../../../src/services/tech-record-document-conversion', () => ({
   techRecordDocumentConverter: jest.fn().mockReturnValue({
@@ -50,3 +52,38 @@ describe('convert()', () => {
     },
   });
 });
+
+// jest.mock('../../../src/services/test-result-record-conversion.ts', () => ({
+//   testResultsConverter: jest.fn().mockReturnValue({
+//     parseRootImage: jest.fn(),
+//     upsertEntity: jest.fn(),
+//     deleteEntity: jest.fn(),
+//   }),
+// }));
+//
+// // Mock sql-execution so that it always returns one row
+// jest.mock('../../../src/services/sql-execution.ts', () => ({
+//   selectRecordIds: jest.fn().mockReturnValue({
+//     rows: [1]
+//   })
+// }));
+//
+// describe('upsertTestResults()', () => {
+//   beforeEach(() => {
+//     // techRecordDocumentConverter().parseRootImage.mockReset();
+//     // techRecordDocumentConverter().upsertEntity.mockReset();
+//     // techRecordDocumentConverter().deleteEntity.mockReset();
+//   });
+//
+//   it("should be ", () => {
+//     convert('technical-records', 'INSERT', exampleImage());
+//
+//     expect(techRecordDocumentConverter().parseRootImage).toHaveBeenCalledTimes(
+//       1,
+//     );
+//     expect(techRecordDocumentConverter().upsertEntity).toHaveBeenCalledTimes(1);
+//     expect(techRecordDocumentConverter().deleteEntity).toHaveBeenCalledTimes(0);
+//   });
+//
+//
+//


### PR DESCRIPTION
## Description

Encompasses small changes made to update store to accommodate for vrm being recorded at time of test on a test result (see [CB2-13302](https://dvsa.atlassian.net/browse/CB2-13302)). 

Note that despite the below ticket of work suggesting we delete the upsert to the vehicle table all together - this caused some tests to fail. By upserting only in the case that no vehicle existed with that system number and vin, these tests then passed. 
- Upserting is only done in this case, otherwise we select the vehicle id from the vehicle table.

Accompanied with this change is the following additions to the integration tests for test results:
- Add vrm_trm to the tests to ensure its value is propagated to NOP.
- Add new test case where a vehicle exists in NOP already but we change the VRM on the test result. Expected behaviour here is that the VRM change **does not** get propagated to the vehicle table **but does** get propagated to the test result table on the new vrm_trm field.

Related issue: [CB2-13302](https://dvsa.atlassian.net/browse/CB2-13302)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?



[CB2-13302]: https://dvsa.atlassian.net/browse/CB2-13302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB2-13302]: https://dvsa.atlassian.net/browse/CB2-13302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ