### PR TITLE
Feature/cb2 19647 - Add Vehicle Load Status to Test Result schema in NOP

### DIFF
--- a/src/models/test-types.ts
+++ b/src/models/test-types.ts
@@ -27,6 +27,41 @@ export type FuelType =
   | 'petrol'
   | 'full electric';
 
+export type VehicleLoadStatus =
+  | 'Unladen'
+  | 'Partially laden'
+  | 'Partially laden 50% to 65%'
+  | 'Fully laden'
+  | 'Load simulated partially laden'
+  | 'Load simulated fully laden';
+
+export type UnladenBodyType =
+  | 'Skeletal'
+  | 'Curtain'
+  | 'Fridge'
+  | 'Box'
+  | 'Tank'
+  | 'Flat'
+  | 'Car transporter'
+  | 'Fixed plant'
+  | 'Tipper'
+  | 'Refuge'
+  | 'Street cleaner'
+  | 'Specialised vehicle/trailer'
+  | 'Other';
+
+export type ReasonForNotLoading =
+  | 'Obnoxious load'
+  | 'Tanker'
+  | 'Perishable goods'
+  | 'Livestock'
+  | 'Car transporter'
+  | 'Refuge'
+  | 'Street cleaner'
+  | 'ULTAST'
+  | 'Specialist body/load'
+  | 'Other';
+
 export type TestTypes = TestType[];
 
 export interface TestType {
@@ -64,6 +99,12 @@ export interface TestType {
   smokeTestKLimitApplied?: string;
   defects?: Defects;
   customDefects?: CustomDefects;
+  load_status?: VehicleLoadStatus;
+  unladen_body_type?: UnladenBodyType;
+  other_unladen_body_type?: string;
+  reason_for_not_loading?: ReasonForNotLoading;
+  other_reason_for_not_loading?: string;
+  partially_laden_reason?: string;
 }
 
 export const parseTestTypes = (image?: DynamoDbImage): TestTypes => {
@@ -121,4 +162,10 @@ export const parseTestType = (image: DynamoDbImage): TestType => ({
   smokeTestKLimitApplied: image.getString('smokeTestKLimitApplied'),
   defects: parseDefects(image.getList('defects')),
   customDefects: parseCustomDefects(image.getList('customDefects')),
+  load_status: image.getString('load_status') as VehicleLoadStatus,
+  unladen_body_type: image.getString('unladen_body_type') as UnladenBodyType,
+  other_unladen_body_type: image.getString('other_unladen_body_type'),
+  reason_for_not_loading: image.getString('reason_for_not_loading') as ReasonForNotLoading,
+  other_reason_for_not_loading: image.getString('other_reason_for_not_loading'),
+  partially_laden_reason: image.getString('partially_laden_reason'),
 });

--- a/src/services/table-details.ts
+++ b/src/services/table-details.ts
@@ -365,6 +365,26 @@ export const TEST_RESULT_TABLE: TableDetails = {
   ],
 };
 
+export const LOAD_STATUE_TABLE: TableDetails = {
+  tableName: 'load_status',
+  columnNames: ['load_status'],
+};
+
+export const UNLADEN_BODY_TYPE_TABLE: TableDetails = {
+  tableName: 'unladen_body_type',
+  columnNames: ['unladen_body_type'],
+};
+
+export const REASON_FOR_NOT_LOADING_TABLE: TableDetails = {
+  tableName: 'reason_for_not_loading',
+  columnNames: ['reason_for_not_loading'],
+};
+
+export const VEHICLE_LOAD_STATUS_TABLE: TableDetails = {
+  tableName: 'vehicle_load_status',
+  columnNames: ['test_type_id', 'load_status_id', 'unladen_body_type_id', 'other_unladen_body_type', 'reason_for_not_loading_id', 'other_reason_for_not_loading', 'partially_laden_reason'],
+};
+
 export const allTables = (): TableDetails[] => [
   VEHICLE_TABLE,
   MAKE_MODEL_TABLE,
@@ -389,4 +409,8 @@ export const allTables = (): TableDetails[] => [
   TEST_DEFECT_TABLE,
   CUSTOM_DEFECT_TABLE,
   TEST_RESULT_TABLE,
+  LOAD_STATUE_TABLE,
+  UNLADEN_BODY_TYPE_TABLE,
+  REASON_FOR_NOT_LOADING_TABLE,
+  VEHICLE_LOAD_STATUS_TABLE,
 ];

--- a/src/services/test-result-record-conversion.ts
+++ b/src/services/test-result-record-conversion.ts
@@ -24,6 +24,10 @@ import {
   VEHICLE_CLASS_TABLE,
   VEHICLE_SUBCLASS_TABLE,
   VEHICLE_TABLE,
+  LOAD_STATUE_TABLE,
+  UNLADEN_BODY_TYPE_TABLE,
+  REASON_FOR_NOT_LOADING_TABLE,
+  VEHICLE_LOAD_STATUS_TABLE,
 } from './table-details';
 import {
   deleteBasedOnWhereIn,
@@ -123,6 +127,58 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
         testResult.lastUpdatedByName!,
       );
 
+      if (!process.env.DISABLE_DELETE_ON_UPDATE) {
+        const existingTestResultIds = await selectRecordIds(
+          TEST_RESULT_TABLE.tableName,
+          { vehicle_id: vehicleId, testResultId: testResult.testResultId },
+          testResultConnection,
+        );
+        if (existingTestResultIds.rows.length > 0) {
+          await testResultConnection.beginTransaction();
+
+          const testResultIds = existingTestResultIds.rows.map(
+            (row: { id: any }) => row.id,
+          );
+          const testResultIdPlaceholders = testResultIds.map(() => '?').join(', ');
+          const [existingTestTypeRows] = await testResultConnection.execute(
+            `SELECT test_type_id FROM ${TEST_RESULT_TABLE.tableName} WHERE id IN (${testResultIdPlaceholders})`,
+            testResultIds,
+          );
+          const testTypeIds = (existingTestTypeRows as { test_type_id: any }[])
+            .map((row) => row.test_type_id)
+            .filter((id) => id != null);
+
+          await deleteBasedOnWhereIn(
+            CUSTOM_DEFECT_TABLE.tableName,
+            'test_result_id',
+            testResultIds,
+            testResultConnection,
+          );
+          await deleteBasedOnWhereIn(
+            TEST_DEFECT_TABLE.tableName,
+            'test_result_id',
+            testResultIds,
+            testResultConnection,
+          );
+          if (testTypeIds.length > 0) {
+            await deleteBasedOnWhereIn(
+              VEHICLE_LOAD_STATUS_TABLE.tableName,
+              'test_type_id',
+              testTypeIds,
+              testResultConnection,
+            );
+          }
+          await deleteBasedOnWhereIn(
+            TEST_RESULT_TABLE.tableName,
+            'id',
+            testResultIds,
+            testResultConnection,
+          );
+
+          await testResultConnection.commit();
+        }
+      }
+
       if (!testResult.testTypes || testResult.testTypes.length < 1) {
         await executeFullUpsert(
           TEST_RESULT_TABLE,
@@ -219,6 +275,7 @@ const upsertTestResults = async (testResults: TestResults): Promise<void> => {
           testType,
         );
         const testTypeId = await upsertTestType(testResultConnection, testType);
+        await upsertVehicleLoadStatus(testResultConnection, testType, testTypeId);
 
         debugLog('upsertTestResults: Upserting test result...');
 
@@ -610,4 +667,119 @@ const upsertCustomDefects = async (
       `upsertTestResults: Upserted custom defect (ID: ${response.rows.insertId})`,
     );
   }
+};
+
+const upsertLoadStatus = async (
+  connection: Connection,
+  load_status: string,
+): Promise<number> => {
+  debugLog(`upsertTestResults: Upserting load status (${load_status})...`);
+
+  const existingLoadStatusIds = await selectRecordIds(
+    LOAD_STATUE_TABLE.tableName,
+    { load_status },
+    connection,
+  );
+
+  if (existingLoadStatusIds.rows.length > 0) {
+    return existingLoadStatusIds.rows[0].id;
+  }
+
+  const response = await executePartialUpsert(LOAD_STATUE_TABLE, [load_status], connection);
+
+  debugLog(
+    `upsertTestResults: Upserted load status (ID: ${response.rows.insertId})`,
+  );
+
+  return response.rows.insertId;
+};
+
+const upsertUnladenBodyType = async (
+  connection: Connection,
+  unladen_body_type: string,
+): Promise<number> => {
+  debugLog(`upsertTestResults: Upserting unladen body type (${unladen_body_type})...`);
+
+  const existingUnladenBodyTypeIds = await selectRecordIds(
+    UNLADEN_BODY_TYPE_TABLE.tableName,
+    { unladen_body_type },
+    connection,
+  );
+
+  if (existingUnladenBodyTypeIds.rows.length > 0) {
+    return existingUnladenBodyTypeIds.rows[0].id;
+  }
+
+  const response = await executePartialUpsert(UNLADEN_BODY_TYPE_TABLE, [unladen_body_type], connection);
+
+  debugLog(
+    `upsertTestResults: Upserted unladen body type (ID: ${response.rows.insertId})`,
+  );
+
+  return response.rows.insertId;
+};
+
+const upsertReasonForNotLoading = async (
+  connection: Connection,
+  reason_for_not_loading: string,
+): Promise<number> => {
+  debugLog(`upsertTestResults: Upserting reason for not loading (${reason_for_not_loading})...`);
+
+  const existingReasonForNotLoadingIds = await selectRecordIds(
+    REASON_FOR_NOT_LOADING_TABLE.tableName,
+    { reason_for_not_loading },
+    connection,
+  );
+
+  if (existingReasonForNotLoadingIds.rows.length > 0) {
+    return existingReasonForNotLoadingIds.rows[0].id;
+  }
+
+  const response = await executePartialUpsert(REASON_FOR_NOT_LOADING_TABLE, [reason_for_not_loading], connection);
+
+  debugLog(
+    `upsertTestResults: Upserted reason for not loading (ID: ${response.rows.insertId})`,
+  );
+
+  return response.rows.insertId;
+};
+
+const upsertVehicleLoadStatus = async (
+  connection: Connection,
+  testType: TestType,
+  testTypeId: number,
+): Promise<number> => {
+  debugLog('upsertTestResults: Upserting test type vehicle load status...');
+
+  // REASON_FOR_NOT_LOADING_TABLE,
+
+  const loadStatusId = testType.load_status != null
+    ? await upsertLoadStatus(connection, testType.load_status)
+    : null;
+  const unladenBodyTypeId = testType.unladen_body_type != null
+    ? await upsertUnladenBodyType(connection, testType.unladen_body_type)
+    : null;
+  const reasonForNotLoadingId = testType.reason_for_not_loading != null
+    ? await upsertReasonForNotLoading(connection, testType.reason_for_not_loading)
+    : null;
+
+  const response = await executePartialUpsert(
+    VEHICLE_LOAD_STATUS_TABLE,
+    [
+      testTypeId,
+      loadStatusId,
+      unladenBodyTypeId,
+      testType.other_unladen_body_type,
+      reasonForNotLoadingId,
+      testType.other_reason_for_not_loading,
+      testType.partially_laden_reason,
+    ],
+    connection,
+  );
+
+  debugLog(
+    `upsertTestResults: Upserted test type vehicle load status (ID: ${response.rows.insertId})`,
+  );
+
+  return response.rows.insertId;
 };

--- a/tests/integration/test-results-conversion-with-vehicle-load-status.intTest.ts
+++ b/tests/integration/test-results-conversion-with-vehicle-load-status.intTest.ts
@@ -1,0 +1,192 @@
+/* eslint-disable global-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { StartedTestContainer } from 'testcontainers';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import {
+  destroyConnectionPool,
+  executeSql,
+} from '../../src/services/connection-pool';
+import { exampleContext, useLocalDb } from '../utils';
+import { getContainerizedDatabase } from './cvsbnop-container';
+import { processStreamEvent } from '../../src/functions/process-stream-event';
+import { getConnectionPoolOptions } from '../../src/services/connection-pool-options';
+
+useLocalDb();
+jest.setTimeout(60_000);
+
+describe('convertTestResults() integration tests with vehicle load status', () => {
+  let container: StartedTestContainer;
+  const testResultsJsonWithVehicleLoadStatus = JSON.parse(
+    JSON.stringify(
+      require('../resources/dynamodb-image-test-result-with-vehicle-load-status.json'),
+    ),
+  );
+  const testResultId = testResultsJsonWithVehicleLoadStatus.testResultId.S;
+
+  beforeAll(async () => {
+    delete process.env.DISABLE_DELETE_ON_UPDATE;
+    jest.restoreAllMocks();
+
+    // see README for why this environment variable exists
+    if (process.env.USE_CONTAINERIZED_DATABASE === '1') {
+      container = await getContainerizedDatabase();
+    } else {
+      (getConnectionPoolOptions as jest.Mock) = jest.fn().mockResolvedValue({
+        host: '127.0.0.1',
+        port: '3306',
+        user: 'root',
+        password: '12345',
+        database: 'CVSBNOP',
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await destroyConnectionPool();
+    if (process.env.USE_CONTAINERIZED_DATABASE === '1' && container) {
+      await container.stop();
+    }
+  });
+
+  it('should correctly convert vehicle load status into Aurora rows', async () => {
+    await processStreamEvent(
+      buildEvent(testResultsJsonWithVehicleLoadStatus),
+      exampleContext(),
+      jest.fn(),
+    );
+
+    const vehicleLoadStatusSet = await selectVehicleLoadStatus();
+
+    expect(vehicleLoadStatusSet.rows).toEqual([
+      {
+        testNumber: 'LOAD-STATUS-1',
+        load_status: 'Unladen',
+        unladen_body_type: 'Box',
+        other_unladen_body_type: 'LOAD-OTHER-BODY',
+        reason_for_not_loading: 'Tanker',
+        other_reason_for_not_loading: 'LOAD-OTHER-REASON',
+        partially_laden_reason: 'LOAD-PARTIAL-REASON',
+      },
+      {
+        testNumber: 'LOAD-STATUS-2',
+        load_status: null,
+        unladen_body_type: null,
+        other_unladen_body_type: null,
+        reason_for_not_loading: null,
+        other_reason_for_not_loading: null,
+        partially_laden_reason: null,
+      },
+    ]);
+
+    const nullLookupRows = await selectNullLookupRows();
+    expect(nullLookupRows.rows).toEqual([
+      { table_name: 'load_status', row_count: 0 },
+      { table_name: 'reason_for_not_loading', row_count: 0 },
+      { table_name: 'unladen_body_type', row_count: 0 },
+    ]);
+  });
+
+  it('should replace old vehicle load status rows when the test result is updated', async () => {
+    const updatedTestResult = unmarshall(testResultsJsonWithVehicleLoadStatus);
+    updatedTestResult.testTypes[0].load_status = 'Fully laden';
+    delete updatedTestResult.testTypes[0].unladen_body_type;
+    delete updatedTestResult.testTypes[0].reason_for_not_loading;
+    updatedTestResult.testTypes[0].other_unladen_body_type = 'UPDATED-OTHER-BODY';
+    updatedTestResult.testTypes[0].other_reason_for_not_loading = 'UPDATED-OTHER-REASON';
+    updatedTestResult.testTypes[0].partially_laden_reason = 'UPDATED-PARTIAL-REASON';
+    updatedTestResult.testTypes[1].load_status = 'Partially laden';
+    updatedTestResult.testTypes[1].reason_for_not_loading = 'Other';
+
+    await processStreamEvent(
+      buildEvent(marshall(updatedTestResult), 'MODIFY'),
+      exampleContext(),
+      jest.fn(),
+    );
+
+    const vehicleLoadStatusSet = await selectVehicleLoadStatus();
+
+    expect(vehicleLoadStatusSet.rows).toEqual([
+      {
+        testNumber: 'LOAD-STATUS-1',
+        load_status: 'Fully laden',
+        unladen_body_type: null,
+        other_unladen_body_type: 'UPDATED-OTHER-BODY',
+        reason_for_not_loading: null,
+        other_reason_for_not_loading: 'UPDATED-OTHER-REASON',
+        partially_laden_reason: 'UPDATED-PARTIAL-REASON',
+      },
+      {
+        testNumber: 'LOAD-STATUS-2',
+        load_status: 'Partially laden',
+        unladen_body_type: null,
+        other_unladen_body_type: null,
+        reason_for_not_loading: 'Other',
+        other_reason_for_not_loading: null,
+        partially_laden_reason: null,
+      },
+    ]);
+
+    const oldVehicleLoadStatusSet = await executeSql(
+      `SELECT vls.id
+          FROM vehicle_load_status vls
+          INNER JOIN test_result tr ON vls.test_type_id = tr.test_type_id
+          LEFT JOIN load_status ls ON vls.load_status_id = ls.id
+          LEFT JOIN unladen_body_type ubt ON vls.unladen_body_type_id = ubt.id
+          LEFT JOIN reason_for_not_loading rfnl ON vls.reason_for_not_loading_id = rfnl.id
+          WHERE tr.testResultId = "${testResultId}"
+            AND (
+              ls.load_status = "Unladen"
+              OR ubt.unladen_body_type = "Box"
+              OR rfnl.reason_for_not_loading = "Tanker"
+            )`,
+    );
+    expect(oldVehicleLoadStatusSet.rows).toHaveLength(0);
+  });
+
+  function buildEvent(newImage: any, eventName = 'INSERT') {
+    return {
+      Records: [
+        {
+          body: JSON.stringify({
+            eventSourceARN:
+            'arn:aws:dynamodb:eu-west-1:1:table/test-results/stream/2020-01-01T00:00:00.000',
+            eventName,
+            dynamodb: {
+              NewImage: newImage,
+            },
+          }),
+        },
+      ],
+    };
+  }
+
+  async function selectVehicleLoadStatus() {
+    return executeSql(
+      `SELECT tr.testNumber,
+              ls.load_status,
+              ubt.unladen_body_type,
+              vls.other_unladen_body_type,
+              rfnl.reason_for_not_loading,
+              vls.other_reason_for_not_loading,
+              vls.partially_laden_reason
+          FROM vehicle_load_status vls
+          INNER JOIN test_result tr ON vls.test_type_id = tr.test_type_id
+          LEFT JOIN load_status ls ON vls.load_status_id = ls.id
+          LEFT JOIN unladen_body_type ubt ON vls.unladen_body_type_id = ubt.id
+          LEFT JOIN reason_for_not_loading rfnl ON vls.reason_for_not_loading_id = rfnl.id
+          WHERE tr.testResultId = "${testResultId}"
+          ORDER BY tr.testNumber`,
+    );
+  }
+
+  async function selectNullLookupRows() {
+    return executeSql(
+      `SELECT "load_status" table_name, COUNT(*) row_count FROM load_status WHERE load_status IS NULL
+          UNION ALL
+        SELECT "reason_for_not_loading" table_name, COUNT(*) row_count FROM reason_for_not_loading WHERE reason_for_not_loading IS NULL
+          UNION ALL
+        SELECT "unladen_body_type" table_name, COUNT(*) row_count FROM unladen_body_type WHERE unladen_body_type IS NULL
+          ORDER BY table_name`,
+    );
+  }
+});

--- a/tests/resources/dynamodb-image-test-result-with-vehicle-load-status.json
+++ b/tests/resources/dynamodb-image-test-result-with-vehicle-load-status.json
@@ -1,0 +1,299 @@
+{
+  "systemNumber": {
+    "S": "SYSTEM-NUMBER-LOAD-STATUS"
+  },
+  "vrm": {
+    "S": "VRM-LOAD-STATUS"
+  },
+  "trailerId": {
+    "S": "TRL-LOAD-STATUS"
+  },
+  "vin": {
+    "S": "VIN-LOAD-STATUS"
+  },
+  "vehicleId": {
+    "S": "VEHICLE-ID-LOAD-STATUS"
+  },
+  "testHistory": {
+    "L": []
+  },
+  "testVersion": {
+    "S": "TEST-VERSION-LOAD-STATUS"
+  },
+  "reasonForCreation": {
+    "S": "REASON-FOR-CREATION-LOAD-STATUS"
+  },
+  "createdAt": {
+    "S": "2020-01-01T00:00:00.000Z"
+  },
+  "createdByName": {
+    "S": "CREATED-BY-NAME-LOAD-STATUS"
+  },
+  "createdById": {
+    "S": "CREATED-BY-ID-LOAD-STATUS"
+  },
+  "lastUpdatedAt": {
+    "S": "2020-01-01T00:00:00.000Z"
+  },
+  "lastUpdatedByName": {
+    "S": "LAST-UPDATED-BY-NAME-LOAD-STATUS"
+  },
+  "lastUpdatedById": {
+    "S": "LAST-UPDATED-BY-ID-LOAD-STATUS"
+  },
+  "shouldEmailCertificate": {
+    "S": "SHOULD-EMAIL-CERTIFICATE-LOAD-STATUS"
+  },
+  "testStationName": {
+    "S": "TEST-STATION-NAME-LOAD-STATUS"
+  },
+  "testStationPNumber": {
+    "S": "P-NUMBER-LOAD-STATUS"
+  },
+  "testStationType": {
+    "S": "atf"
+  },
+  "testerName": {
+    "S": "TESTER-NAME-LOAD-STATUS"
+  },
+  "testerStaffId": {
+    "S": "999999997"
+  },
+  "testResultId": {
+    "S": "TEST-RESULT-ID-LOAD-STATUS"
+  },
+  "testerEmailAddress": {
+    "S": "TESTER-EMAIL-ADDRESS-LOAD-STATUS"
+  },
+  "testStartTimestamp": {
+    "S": "2020-01-01T00:00:00.000Z"
+  },
+  "testEndTimestamp": {
+    "S": "2020-01-01T00:00:00.000Z"
+  },
+  "testStatus": {
+    "S": "submitted"
+  },
+  "reasonForCancellation": {
+    "S": "REASON-FOR-CANCELLATION-LOAD-STATUS"
+  },
+  "vehicleClass": {
+    "M": {
+      "code": {
+        "S": "v"
+      },
+      "description": {
+        "S": "heavy goods vehicle"
+      }
+    }
+  },
+  "vehicleSubclass": {
+    "L": [
+      {
+        "S": "2"
+      }
+    ]
+  },
+  "vehicleType": {
+    "S": "hgv"
+  },
+  "numberOfSeats": {
+    "N": "1"
+  },
+  "vehicleConfiguration": {
+    "S": "rigid"
+  },
+  "odometerReading": {
+    "N": "1"
+  },
+  "odometerReadingUnits": {
+    "S": "KILOMETRES"
+  },
+  "preparerId": {
+    "S": "999999997"
+  },
+  "preparerName": {
+    "S": "PREPARER-NAME-LOAD-STATUS"
+  },
+  "numberOfWheelsDriven": {
+    "N": "1"
+  },
+  "euVehicleCategory": {
+    "S": "m1"
+  },
+  "countryOfRegistration": {
+    "S": "COUNTRY-OF-REGISTRATION-LOAD-STATUS"
+  },
+  "vehicleSize": {
+    "S": "large"
+  },
+  "noOfAxles": {
+    "N": "4"
+  },
+  "regnDate": {
+    "S": "2020-01-01"
+  },
+  "firstUseDate": {
+    "S": "2020-01-01"
+  },
+  "testTypes": {
+    "L": [
+      {
+        "M": {
+          "createdAt": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "lastUpdatedAt": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "deletionFlag": {
+            "BOOL": true
+          },
+          "testCode": {
+            "S": "333"
+          },
+          "testTypeClassification": {
+            "S": "Annual With Certificate"
+          },
+          "testTypeName": {
+            "S": "Annual test with load status"
+          },
+          "name": {
+            "S": "Annual test"
+          },
+          "testTypeId": {
+            "S": "94"
+          },
+          "testNumber": {
+            "S": "LOAD-STATUS-1"
+          },
+          "certificateNumber": {
+            "S": "LOAD-CERT-1"
+          },
+          "secondaryCertificateNumber": {
+            "S": "LOAD-CERT-2"
+          },
+          "certificateLink": {
+            "S": "CERTIFICATE-LINK"
+          },
+          "testExpiryDate": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "testAnniversaryDate": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "testTypeStartTimestamp": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "testTypeEndTimestamp": {
+            "S": "2020-01-01T16:54:44.123Z"
+          },
+          "statusUpdatedFlag": {
+            "BOOL": true
+          },
+          "numberOfSeatbeltsFitted": {
+            "N": "1"
+          },
+          "lastSeatbeltInstallationCheckDate": {
+            "S": "2020-01-01"
+          },
+          "seatbeltInstallationCheckDate": {
+            "BOOL": true
+          },
+          "testResult": {
+            "S": "pass"
+          },
+          "prohibitionIssued": {
+            "BOOL": false
+          },
+          "additionalNotesRecorded": {
+            "S": "ADDITIONAL-NOTES-RECORDED"
+          },
+          "modType": {
+            "M": {
+              "code": {
+                "S": "p"
+              },
+              "description": {
+                "S": "particulate trap"
+              }
+            }
+          },
+          "emissionStandard": {
+            "S": "0.10 g/kWh Euro 3 PM"
+          },
+          "fuelType": {
+            "S": "diesel"
+          },
+          "load_status": {
+            "S": "Unladen"
+          },
+          "unladen_body_type": {
+            "S": "Box"
+          },
+          "other_unladen_body_type": {
+            "S": "LOAD-OTHER-BODY"
+          },
+          "reason_for_not_loading": {
+            "S": "Tanker"
+          },
+          "other_reason_for_not_loading": {
+            "S": "LOAD-OTHER-REASON"
+          },
+          "partially_laden_reason": {
+            "S": "LOAD-PARTIAL-REASON"
+          }
+        }
+      },
+      {
+        "M": {
+          "createdAt": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "lastUpdatedAt": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "testCode": {
+            "S": "334"
+          },
+          "testTypeClassification": {
+            "S": "Annual With Certificate"
+          },
+          "testTypeName": {
+            "S": "Annual test without load status"
+          },
+          "name": {
+            "S": "Annual test"
+          },
+          "testTypeId": {
+            "S": "95"
+          },
+          "testNumber": {
+            "S": "LOAD-STATUS-2"
+          },
+          "certificateNumber": {
+            "S": "LOAD-CERT-3"
+          },
+          "testExpiryDate": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "testAnniversaryDate": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "testTypeStartTimestamp": {
+            "S": "2020-01-01T00:00:00.000Z"
+          },
+          "testTypeEndTimestamp": {
+            "S": "2020-01-01T17:54:44.123Z"
+          },
+          "testResult": {
+            "S": "pass"
+          },
+          "prohibitionIssued": {
+            "BOOL": false
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Cherry picks commits from https://github.com/dvsa/cvs-tsk-update-store/pull/137 relevant specific to this ticket for 

Introduce a new field in both VTA and VTM to record the mandatory capture of vehicle load status for a HGV or trailer when presented for a full annual test or when conducting an annual retest when the retest has IM numbers 59, 71, 72 and/or 73 or full prohibition ( with or without certificates). This field should capture whether the vehicle/trailer is:

- Unladen
- Partially laden
- Partially laden 50% to 65%
- Fully laden
- Load simulated partially laden
- Load simulated fully laden

### Include a summary of the change here.
Added functions and tests for vehicle load status 

Related issue: [CB2-19647](https://dvsa.atlassian.net/browse/CB2-19647)


## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[CB2-19647]: https://dvsa.atlassian.net/browse/CB2-19647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ